### PR TITLE
fix(workflows): remove duplicate core declaration in github-script

### DIFF
--- a/.github/workflows/weekly-status-bot.yml
+++ b/.github/workflows/weekly-status-bot.yml
@@ -20,8 +20,6 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
-            const core = require("@actions/core")
-
             const owner = context.repo.owner
             const repo = context.repo.repo
             const dateUtc = new Date().toISOString().slice(0, 10)


### PR DESCRIPTION
Removes the explicit \ require from the weekly status workflow github-script step.\n\nThis fixes runtime failure in \ where \ is already injected into the script context, causing a duplicate identifier declaration.\n\nTested by dispatching the workflow after merge.