### PR TITLE
fix(workflows): use real newlines in weekly status issue body

### DIFF
--- a/.github/workflows/weekly-status-bot.yml
+++ b/.github/workflows/weekly-status-bot.yml
@@ -41,7 +41,7 @@ jobs:
               "",
               "### Next-Week Priorities",
               "- ",
-            ].join("\\n")
+            ].join("\n")
 
             const { data: issues } = await github.rest.issues.listForRepo({
               owner,


### PR DESCRIPTION
Fixes markdown formatting in the weekly status issue body. The workflow was joining lines with literal `\\n`, which rendered backslash characters instead of line breaks.\n\nThis switches the join separator to `\n` so headings and lists render correctly in GitHub issues.