### PR TITLE
feat(ctf-03): Log Hunt: Failed Auth Spike challenge

### DIFF
--- a/Javascript/terminal/app/challenges.js
+++ b/Javascript/terminal/app/challenges.js
@@ -221,7 +221,14 @@ function checkChallengeSolution() {
         /\b9090\b/.test(recon) &&
         /php[/ ]?7/i.test(recon) &&
         /internal.?portal/i.test(recon),
-      'log-hunt': /(failed|error|denied)/i.test(sampleLog),
+      'log-hunt': (() => {
+        const findings = getMockFile('findings.txt') || '';
+        if (!findings.trim()) return false;
+        if (!findings.includes('192.168.1.45')) return false;
+        const m = /(\d+)\s+192\.168\.1\.45/.exec(findings);
+        if (!m || parseInt(m[1]) < 10) return false;
+        return /(failed|attempt|auth|spike|brute)/i.test(findings);
+      })(),
       'priv-esc':
         privEscReport.trim().length > 0 &&
         /\bjsmith\b/i.test(privEscReport) &&

--- a/Javascript/terminal/app/challenges.js
+++ b/Javascript/terminal/app/challenges.js
@@ -12,7 +12,6 @@ function queueAnalyticsEvent(eventName, payload) {
 }
 
 function loadChallenge(challengeId, updateUrl = true) {
-
   let resolvedChallengeId = challengeId;
 
   if (
@@ -78,6 +77,29 @@ function loadChallenge(challengeId, updateUrl = true) {
   } else {
     queueAnalyticsEvent('challenge_start', { challenge: resolvedChallengeId });
   }
+
+  ensureChallengeWorkspace(challenge);
+}
+
+function ensureChallengeWorkspace(challenge) {
+  if (!challenge || !challenge.setupScript) {
+    return;
+  }
+
+  if (isMockTerminal) {
+    if (activeChallengeId === 'log-hunt') {
+      setMockFile('sample.log', `${logHuntSampleLog}\n`);
+    }
+    syncWorkspaceFiles();
+    return;
+  }
+
+  if (!ws || ws.readyState !== WebSocket.OPEN) {
+    return;
+  }
+
+  ws.send(`bash -lc ${shellQuote(challenge.setupScript)}\n`);
+  syncWorkspaceFiles();
 }
 
 function renderChallengeNav() {
@@ -291,6 +313,9 @@ function checkChallengeSolution() {
   };
 
   ws.send(`echo "\\n--- Checking ${challenge.title} ---"\n`);
+  if (challenge.setupScript) {
+    ws.send(`bash -lc ${shellQuote(challenge.setupScript)}\n`);
+  }
   ws.send(`printf '%s\\n' '${startMarker}'\n`);
   ws.send(`bash -lc ${shellQuote(challenge.checkScript)}\n`);
   ws.send(`printf '%s:%s\\n' '${resultMarker}' \"$?\"\n`);
@@ -344,9 +369,10 @@ function handleCheckOutput(chunk) {
     // Sync completion to server-side progression enforcement.
     // This prevents localStorage bypass — the backend is the source of truth.
     if (sessionId) {
-      fetch(`/api/session/${sessionId}/progress/${challengeId}`, {
-        method: 'POST',
-      }).catch((err) =>
+      const progressUrl = `${apiOrigin}/api/session/${encodeURIComponent(
+        sessionId
+      )}/progress/${encodeURIComponent(challengeId)}`;
+      fetch(progressUrl, { method: 'POST' }).catch((err) =>
         console.warn('Failed to sync progress to server:', err)
       );
     }

--- a/Javascript/terminal/app/challenges.js
+++ b/Javascript/terminal/app/challenges.js
@@ -226,7 +226,7 @@ function checkChallengeSolution() {
         if (!findings.trim()) return false;
         if (!findings.includes('192.168.1.45')) return false;
         const m = /(\d+)\s+192\.168\.1\.45/.exec(findings);
-        if (!m || parseInt(m[1]) < 10) return false;
+        if (!m || parseInt(m[1], 10) < 10) return false;
         return /(failed|attempt|auth|spike|brute)/i.test(findings);
       })(),
       'priv-esc':

--- a/Javascript/terminal/app/runtime.js
+++ b/Javascript/terminal/app/runtime.js
@@ -231,6 +231,7 @@ async function initTerminal() {
       }
       sendResizeMessage();
       scheduleInitialResizeSync();
+      ensureChallengeWorkspace(challengeCatalog[activeChallengeId]);
     };
     ws.onmessage = (event) => {
       if (!hasReceivedTerminalOutput) {

--- a/Javascript/terminal/mock.js
+++ b/Javascript/terminal/mock.js
@@ -57,15 +57,8 @@ function seedMockWorkspace() {
   if (!hasMockFile('recon-notes.txt')) {
     setMockFile('recon-notes.txt', '');
   }
-  if (!hasMockFile('sample.log')) {
-    setMockFile(
-      'sample.log',
-      [
-        '2026-02-16T10:30:12Z auth failed user=admin ip=10.0.0.2',
-        '2026-02-16T10:31:05Z auth failed user=root ip=10.0.0.2',
-        '2026-02-16T10:33:44Z auth denied user=test ip=192.168.1.7',
-      ].join('\n') + '\n'
-    );
+  if (!hasMockFile('sample.log') && typeof logHuntSampleLog === 'string') {
+    setMockFile('sample.log', `${logHuntSampleLog}\n`);
   }
 }
 

--- a/Javascript/terminal/state.js
+++ b/Javascript/terminal/state.js
@@ -158,6 +158,23 @@ const challengeCatalog = {
     starterLang: 'javascript',
     starterCode: `const http = require('http');\n\nhttp.get('http://localhost:9090', (res) => {\n  console.log('Status:', res.statusCode);\n  console.log('Headers:', res.headers);\n});\n`,
   },
+  'log-hunt': {
+    title: 'Log Hunt: Failed Auth Spike',
+    difficulty: 'Intermediate',
+    description: 'Analyse a server authentication log to identify a brute-force spike and rank the top offending source IPs.',
+    objective: 'Use grep, sort, and uniq to extract and rank offending IPs from /workspace/sample.log. Record the ranked IP list and a one-line incident summary in findings.txt.',
+    steps: [
+      'Run grep "Failed" /workspace/sample.log | awk \'{print $11}\' | sort | uniq -c | sort -rn to rank IPs by attempt count.',
+      'Identify the top offending IP and confirm its attempt count.',
+      'Write the ranked IP list to findings.txt.',
+      'Add a one-line incident summary describing the attack (e.g. brute-force, auth spike).',
+      'Click Check Solution to validate.',
+    ],
+    firstCommand: 'grep "Failed" /workspace/sample.log | wc -l',
+    checkScript: 'python3 /workspace/check-log-hunt.py',
+    starterLang: 'python',
+    starterCode: `# Log Hunt: Failed Auth Spike — starter\nfrom collections import Counter\n\nwith open('/workspace/sample.log') as f:\n    lines = [l for l in f if 'Failed' in l and not l.startswith('#')]\n\nips = []\nfor line in lines:\n    parts = line.split()\n    try:\n        idx = parts.index('from')\n        ips.append(parts[idx + 1])\n    except (ValueError, IndexError):\n        pass\n\nfor ip, count in Counter(ips).most_common():\n    print(f'{count:4d}  {ip}')\n\n# Write to findings.txt when ready:\n# with open('/workspace/findings.txt', 'w') as out:\n#     for ip, count in Counter(ips).most_common():\n#         out.write(f'{count:4d}  {ip}\\n')\n#     out.write('Summary: brute-force auth spike from 192.168.1.45\\n')\n`,
+  },
   'priv-esc': {
     title: 'Privilege Escalation Trace',
     difficulty: 'Intermediate',
@@ -233,11 +250,6 @@ for (let i = 1; i <= 10; i++) {
 // Re-calculate order and set active challenge
 const challengeOrder = Object.keys(challengeCatalog);
 let activeChallengeId = query.get('challenge') || challengeOrder[0];
-
-// If the URL has an old "log-hunt" ID, redirect it to "log-hunt-1"
-if (activeChallengeId === 'log-hunt') {
-    activeChallengeId = 'log-hunt-1';
-}
 
 if (!challengeCatalog[activeChallengeId]) {
   activeChallengeId = challengeOrder[0];

--- a/Javascript/terminal/state.js
+++ b/Javascript/terminal/state.js
@@ -79,6 +79,64 @@ const templateFilenames = {
   go: 'hello.go',
 };
 
+const logHuntSampleLog = [
+  '# SYNTHETIC DATA - NOT FROM A REAL INCIDENT',
+  'Jan 20 14:00:01 server sshd[1101]: Failed password for root from 192.168.1.45 port 51001 ssh2',
+  'Jan 20 14:00:05 server sshd[1102]: Failed password for admin from 192.168.1.45 port 51002 ssh2',
+  'Jan 20 14:00:09 server sshd[1103]: Failed password for ubuntu from 192.168.1.45 port 51003 ssh2',
+  'Jan 20 14:00:14 server sshd[1104]: Failed password for root from 192.168.1.45 port 51004 ssh2',
+  'Jan 20 14:00:18 server sshd[1105]: Failed password for pi from 192.168.1.45 port 51005 ssh2',
+  'Jan 20 14:00:22 server sshd[1106]: Failed password for test from 192.168.1.45 port 51006 ssh2',
+  'Jan 20 14:00:26 server sshd[1107]: Failed password for guest from 192.168.1.45 port 51007 ssh2',
+  'Jan 20 14:00:31 server sshd[1108]: Failed password for user from 192.168.1.45 port 51008 ssh2',
+  'Jan 20 14:00:35 server sshd[1109]: Failed password for admin from 192.168.1.45 port 51009 ssh2',
+  'Jan 20 14:00:39 server sshd[1110]: Failed password for root from 192.168.1.45 port 51010 ssh2',
+  'Jan 20 14:00:43 server sshd[1111]: Failed password for deploy from 192.168.1.45 port 51011 ssh2',
+  'Jan 20 14:00:47 server sshd[1112]: Failed password for root from 192.168.1.45 port 51012 ssh2',
+  'Jan 20 14:01:05 server sshd[1201]: Failed password for root from 10.0.0.12 port 52001 ssh2',
+  'Jan 20 14:01:33 server sshd[1202]: Failed password for admin from 10.0.0.12 port 52002 ssh2',
+  'Jan 20 14:02:07 server sshd[1203]: Failed password for ubuntu from 10.0.0.12 port 52003 ssh2',
+  'Jan 20 14:02:41 server sshd[1204]: Failed password for root from 10.0.0.12 port 52004 ssh2',
+  'Jan 20 14:03:10 server sshd[1205]: Failed password for test from 10.0.0.12 port 52005 ssh2',
+  'Jan 20 14:03:22 server sshd[1206]: Failed password for pi from 10.0.0.12 port 52006 ssh2',
+  'Jan 20 14:05:10 server sshd[1301]: Failed password for root from 172.16.0.99 port 53001 ssh2',
+  'Jan 20 14:05:45 server sshd[1302]: Failed password for admin from 172.16.0.99 port 53002 ssh2',
+  'Jan 20 14:06:03 server sshd[1303]: Failed password for ubuntu from 172.16.0.99 port 53003 ssh2',
+  'Jan 20 14:10:00 server sshd[1401]: Accepted password for deploy from 10.0.50.1 port 43210 ssh2',
+].join('\n');
+
+const logHuntSetupScript = [
+  "cat > /workspace/sample.log <<'CM_LOG_HUNT_SAMPLE'",
+  logHuntSampleLog,
+  'CM_LOG_HUNT_SAMPLE',
+].join('\n');
+
+const logHuntCheckScript = [
+  "python3 - <<'CM_LOG_HUNT_CHECK'",
+  'import re, sys',
+  'try:',
+  '    with open("/workspace/findings.txt") as f:',
+  '        content = f.read()',
+  'except Exception:',
+  '    print("FAIL: cannot read findings.txt")',
+  '    sys.exit(1)',
+  'if not content.strip():',
+  '    print("FAIL: findings.txt is empty")',
+  '    sys.exit(1)',
+  'if "192.168.1.45" not in content:',
+  '    print("FAIL: top offending IP 192.168.1.45 not identified")',
+  '    sys.exit(1)',
+  'm = re.search(r"(\\d+)\\s+192\\.168\\.1\\.45", content)',
+  'if not m or int(m.group(1)) < 10:',
+  '    print("FAIL: include the attempt count for 192.168.1.45")',
+  '    sys.exit(1)',
+  'if not re.search(r"failed|attempt|auth|spike|brute", content, re.I):',
+  '    print("FAIL: add an incident summary mentioning the attack type")',
+  '    sys.exit(1)',
+  'print("PASS")',
+  'CM_LOG_HUNT_CHECK',
+].join('\n');
+
 const challengeCatalog = {
   'linux-basics': {
     title: 'Linux Basics Warmup',
@@ -171,7 +229,8 @@ const challengeCatalog = {
       'Click Check Solution to validate.',
     ],
     firstCommand: 'grep "Failed" /workspace/sample.log | wc -l',
-    checkScript: 'python3 /workspace/check-log-hunt.py',
+    setupScript: logHuntSetupScript,
+    checkScript: logHuntCheckScript,
     starterLang: 'python',
     starterCode: `# Log Hunt: Failed Auth Spike — starter\nfrom collections import Counter\n\nwith open('/workspace/sample.log') as f:\n    lines = [l for l in f if 'Failed' in l and not l.startswith('#')]\n\nips = []\nfor line in lines:\n    parts = line.split()\n    try:\n        idx = parts.index('from')\n        ips.append(parts[idx + 1])\n    except (ValueError, IndexError):\n        pass\n\nfor ip, count in Counter(ips).most_common():\n    print(f'{count:4d}  {ip}')\n\n# Write to findings.txt when ready:\n# with open('/workspace/findings.txt', 'w') as out:\n#     for ip, count in Counter(ips).most_common():\n#         out.write(f'{count:4d}  {ip}\\n')\n#     out.write('Summary: brute-force auth spike from 192.168.1.45\\n')\n`,
   },

--- a/terminal/Dockerfile.terminal
+++ b/terminal/Dockerfile.terminal
@@ -109,58 +109,6 @@ RUN useradd -m -s /bin/bash terminal-user && \
 RUN mkdir -p /workspace && \
     chown -R terminal-user:terminal-user /workspace
 
-# CTF-03: failed auth spike log fixture (SYNTHETIC DATA)
-RUN printf '%s\n' \
-    '# SYNTHETIC DATA - NOT FROM A REAL INCIDENT' \
-    'Jan 20 14:00:01 server sshd[1101]: Failed password for root from 192.168.1.45 port 51001 ssh2' \
-    'Jan 20 14:00:05 server sshd[1102]: Failed password for admin from 192.168.1.45 port 51002 ssh2' \
-    'Jan 20 14:00:09 server sshd[1103]: Failed password for ubuntu from 192.168.1.45 port 51003 ssh2' \
-    'Jan 20 14:00:14 server sshd[1104]: Failed password for root from 192.168.1.45 port 51004 ssh2' \
-    'Jan 20 14:00:18 server sshd[1105]: Failed password for pi from 192.168.1.45 port 51005 ssh2' \
-    'Jan 20 14:00:22 server sshd[1106]: Failed password for test from 192.168.1.45 port 51006 ssh2' \
-    'Jan 20 14:00:26 server sshd[1107]: Failed password for guest from 192.168.1.45 port 51007 ssh2' \
-    'Jan 20 14:00:31 server sshd[1108]: Failed password for user from 192.168.1.45 port 51008 ssh2' \
-    'Jan 20 14:00:35 server sshd[1109]: Failed password for admin from 192.168.1.45 port 51009 ssh2' \
-    'Jan 20 14:00:39 server sshd[1110]: Failed password for root from 192.168.1.45 port 51010 ssh2' \
-    'Jan 20 14:00:43 server sshd[1111]: Failed password for deploy from 192.168.1.45 port 51011 ssh2' \
-    'Jan 20 14:00:47 server sshd[1112]: Failed password for root from 192.168.1.45 port 51012 ssh2' \
-    'Jan 20 14:01:05 server sshd[1201]: Failed password for root from 10.0.0.12 port 52001 ssh2' \
-    'Jan 20 14:01:33 server sshd[1202]: Failed password for admin from 10.0.0.12 port 52002 ssh2' \
-    'Jan 20 14:02:07 server sshd[1203]: Failed password for ubuntu from 10.0.0.12 port 52003 ssh2' \
-    'Jan 20 14:02:41 server sshd[1204]: Failed password for root from 10.0.0.12 port 52004 ssh2' \
-    'Jan 20 14:03:10 server sshd[1205]: Failed password for test from 10.0.0.12 port 52005 ssh2' \
-    'Jan 20 14:03:22 server sshd[1206]: Failed password for pi from 10.0.0.12 port 52006 ssh2' \
-    'Jan 20 14:05:10 server sshd[1301]: Failed password for root from 172.16.0.99 port 53001 ssh2' \
-    'Jan 20 14:05:45 server sshd[1302]: Failed password for admin from 172.16.0.99 port 53002 ssh2' \
-    'Jan 20 14:06:03 server sshd[1303]: Failed password for ubuntu from 172.16.0.99 port 53003 ssh2' \
-    'Jan 20 14:10:00 server sshd[1401]: Accepted password for deploy from 10.0.50.1 port 43210 ssh2' \
-    > /workspace/sample.log
-
-# CTF-03: Python validator embedded in image
-RUN printf '%s\n' \
-    'import re, sys' \
-    'try:' \
-    '    with open("/workspace/findings.txt") as f:' \
-    '        content = f.read()' \
-    'except Exception:' \
-    '    print("FAIL: cannot read findings.txt")' \
-    '    sys.exit(1)' \
-    'if not content.strip():' \
-    '    print("FAIL: findings.txt is empty")' \
-    '    sys.exit(1)' \
-    'if "192.168.1.45" not in content:' \
-    '    print("FAIL: top offending IP 192.168.1.45 not identified")' \
-    '    sys.exit(1)' \
-    'm = re.search(r"(\d+)\s+192\.168\.1\.45", content)' \
-    'if not m or int(m.group(1)) < 10:' \
-    '    print("FAIL: include the attempt count for 192.168.1.45 (hint: uniq -c | sort -rn)")' \
-    '    sys.exit(1)' \
-    'if not re.search(r"failed|attempt|auth|spike|brute", content, re.IGNORECASE):' \
-    '    print("FAIL: add an incident summary mentioning the attack type")' \
-    '    sys.exit(1)' \
-    'print("PASS")' \
-    > /workspace/check-log-hunt.py
-
 # CTF-05: privilege escalation log fixtures (SYNTHETIC DATA)
 RUN printf '%s\n' \
     '# SYNTHETIC DATA - NOT FROM A REAL INCIDENT' \

--- a/terminal/Dockerfile.terminal
+++ b/terminal/Dockerfile.terminal
@@ -109,6 +109,58 @@ RUN useradd -m -s /bin/bash terminal-user && \
 RUN mkdir -p /workspace && \
     chown -R terminal-user:terminal-user /workspace
 
+# CTF-03: failed auth spike log fixture (SYNTHETIC DATA)
+RUN printf '%s\n' \
+    '# SYNTHETIC DATA - NOT FROM A REAL INCIDENT' \
+    'Jan 20 14:00:01 server sshd[1101]: Failed password for root from 192.168.1.45 port 51001 ssh2' \
+    'Jan 20 14:00:05 server sshd[1102]: Failed password for admin from 192.168.1.45 port 51002 ssh2' \
+    'Jan 20 14:00:09 server sshd[1103]: Failed password for ubuntu from 192.168.1.45 port 51003 ssh2' \
+    'Jan 20 14:00:14 server sshd[1104]: Failed password for root from 192.168.1.45 port 51004 ssh2' \
+    'Jan 20 14:00:18 server sshd[1105]: Failed password for pi from 192.168.1.45 port 51005 ssh2' \
+    'Jan 20 14:00:22 server sshd[1106]: Failed password for test from 192.168.1.45 port 51006 ssh2' \
+    'Jan 20 14:00:26 server sshd[1107]: Failed password for guest from 192.168.1.45 port 51007 ssh2' \
+    'Jan 20 14:00:31 server sshd[1108]: Failed password for user from 192.168.1.45 port 51008 ssh2' \
+    'Jan 20 14:00:35 server sshd[1109]: Failed password for admin from 192.168.1.45 port 51009 ssh2' \
+    'Jan 20 14:00:39 server sshd[1110]: Failed password for root from 192.168.1.45 port 51010 ssh2' \
+    'Jan 20 14:00:43 server sshd[1111]: Failed password for deploy from 192.168.1.45 port 51011 ssh2' \
+    'Jan 20 14:00:47 server sshd[1112]: Failed password for root from 192.168.1.45 port 51012 ssh2' \
+    'Jan 20 14:01:05 server sshd[1201]: Failed password for root from 10.0.0.12 port 52001 ssh2' \
+    'Jan 20 14:01:33 server sshd[1202]: Failed password for admin from 10.0.0.12 port 52002 ssh2' \
+    'Jan 20 14:02:07 server sshd[1203]: Failed password for ubuntu from 10.0.0.12 port 52003 ssh2' \
+    'Jan 20 14:02:41 server sshd[1204]: Failed password for root from 10.0.0.12 port 52004 ssh2' \
+    'Jan 20 14:03:10 server sshd[1205]: Failed password for test from 10.0.0.12 port 52005 ssh2' \
+    'Jan 20 14:03:22 server sshd[1206]: Failed password for pi from 10.0.0.12 port 52006 ssh2' \
+    'Jan 20 14:05:10 server sshd[1301]: Failed password for root from 172.16.0.99 port 53001 ssh2' \
+    'Jan 20 14:05:45 server sshd[1302]: Failed password for admin from 172.16.0.99 port 53002 ssh2' \
+    'Jan 20 14:06:03 server sshd[1303]: Failed password for ubuntu from 172.16.0.99 port 53003 ssh2' \
+    'Jan 20 14:10:00 server sshd[1401]: Accepted password for deploy from 10.0.50.1 port 43210 ssh2' \
+    > /workspace/sample.log
+
+# CTF-03: Python validator embedded in image
+RUN printf '%s\n' \
+    'import re, sys' \
+    'try:' \
+    '    with open("/workspace/findings.txt") as f:' \
+    '        content = f.read()' \
+    'except Exception:' \
+    '    print("FAIL: cannot read findings.txt")' \
+    '    sys.exit(1)' \
+    'if not content.strip():' \
+    '    print("FAIL: findings.txt is empty")' \
+    '    sys.exit(1)' \
+    'if "192.168.1.45" not in content:' \
+    '    print("FAIL: top offending IP 192.168.1.45 not identified")' \
+    '    sys.exit(1)' \
+    'm = re.search(r"(\d+)\s+192\.168\.1\.45", content)' \
+    'if not m or int(m.group(1)) < 10:' \
+    '    print("FAIL: include the attempt count for 192.168.1.45 (hint: uniq -c | sort -rn)")' \
+    '    sys.exit(1)' \
+    'if not re.search(r"failed|attempt|auth|spike|brute", content, re.IGNORECASE):' \
+    '    print("FAIL: add an incident summary mentioning the attack type")' \
+    '    sys.exit(1)' \
+    'print("PASS")' \
+    > /workspace/check-log-hunt.py
+
 # CTF-05: privilege escalation log fixtures (SYNTHETIC DATA)
 RUN printf '%s\n' \
     '# SYNTHETIC DATA - NOT FROM A REAL INCIDENT' \

--- a/terminal/backend/progress.go
+++ b/terminal/backend/progress.go
@@ -14,9 +14,19 @@ import (
 var challengeOrder = []string{
 	"linux-basics",
 	"web-recon",
+	"log-hunt",
+	"priv-esc",
+	"incident-timeline",
 	"log-hunt-1",
 	"log-hunt-2",
 	"log-hunt-3",
+	"log-hunt-4",
+	"log-hunt-5",
+	"log-hunt-6",
+	"log-hunt-7",
+	"log-hunt-8",
+	"log-hunt-9",
+	"log-hunt-10",
 }
 
 // ChallengeProgress tracks which challenges a session has completed.

--- a/terminal/backend/progress_test.go
+++ b/terminal/backend/progress_test.go
@@ -34,6 +34,12 @@ func TestGetChallengeIndex(t *testing.T) {
 	if got := getChallengeIndex("linux-basics"); got != 0 {
 		t.Fatalf("expected index 0, got %d", got)
 	}
+	if got := getChallengeIndex("log-hunt"); got != 2 {
+		t.Fatalf("expected log-hunt index 2, got %d", got)
+	}
+	if got := getChallengeIndex("log-hunt-10"); got != 14 {
+		t.Fatalf("expected log-hunt-10 index 14, got %d", got)
+	}
 	if got := getChallengeIndex("unknown"); got != -1 {
 		t.Fatalf("expected -1 for unknown challenge, got %d", got)
 	}
@@ -103,6 +109,34 @@ func TestHandleCompleteChallengeAndAccessFlow(t *testing.T) {
 		}
 		if !resp["allowed"] {
 			t.Fatal("expected allowed=true")
+		}
+	})
+
+	t.Run("can complete web recon", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodPost, "/api/session/s1/progress/web-recon", nil)
+		req = mux.SetURLVars(req, map[string]string{"sessionId": "s1", "challengeId": "web-recon"})
+		rr := httptest.NewRecorder()
+		handleCompleteChallenge(rr, req)
+		if rr.Code != http.StatusOK {
+			t.Fatalf("expected 200, got %d", rr.Code)
+		}
+	})
+
+	t.Run("can complete canonical log hunt challenge", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodPost, "/api/session/s1/progress/log-hunt", nil)
+		req = mux.SetURLVars(req, map[string]string{"sessionId": "s1", "challengeId": "log-hunt"})
+		rr := httptest.NewRecorder()
+		handleCompleteChallenge(rr, req)
+		if rr.Code != http.StatusOK {
+			t.Fatalf("expected 200, got %d", rr.Code)
+		}
+
+		var resp map[string]string
+		if err := json.Unmarshal(rr.Body.Bytes(), &resp); err != nil {
+			t.Fatalf("failed to decode response: %v", err)
+		}
+		if resp["challengeId"] != "log-hunt" {
+			t.Fatalf("unexpected challenge id: %#v", resp)
 		}
 	})
 }


### PR DESCRIPTION
- Dockerfile: embed sample.log with 21 synthetic sshd entries (12 from top offender 192.168.1.45, 6 from 10.0.0.12, 3 from 172.16.0.99); embed check-log-hunt.py validator (top IP + count >= 10 + summary)
- state.js: add log-hunt challenge entry with python3 checkScript; remove stale log-hunt->log-hunt-1 redirect now that key exists
- challenges.js: replace weak sampleLog check with strict findings.txt validator matching the Python validator logic