### PR TITLE
feat(frontend): add learner progress and quiz engine

### DIFF
--- a/CSS/Courses and Activities/Course 3/TAandSEquizcourse3.css
+++ b/CSS/Courses and Activities/Course 3/TAandSEquizcourse3.css
@@ -381,6 +381,14 @@ label.selected {
   ); /* Change the background color for the selected label */
 }
 
+label.is-correct {
+  color: lightgreen;
+}
+
+label.is-incorrect {
+  color: #ff8b8b;
+}
+
 .answer-detail {
   display: none;
   margin-top: 0.6px;
@@ -411,4 +419,9 @@ label.selected {
   text-align: center;
   color: #ffffff;
   margin: 0.6em auto 0.6em auto;
+}
+
+.retry-submit {
+  background-color: #16425d;
+  border-color: #286aa7;
 }

--- a/CSS/Courses and Activities/Course 4/TechnicalDefenseQUIZ.css
+++ b/CSS/Courses and Activities/Course 4/TechnicalDefenseQUIZ.css
@@ -381,6 +381,14 @@ label.selected {
   ); /* Change the background color for the selected label */
 }
 
+label.is-correct {
+  color: lightgreen;
+}
+
+label.is-incorrect {
+  color: #ff8b8b;
+}
+
 .answer-detail {
   display: none;
   margin-top: 0.6px;
@@ -411,4 +419,9 @@ label.selected {
   text-align: center;
   color: #ffffff;
   margin: 0.6em auto 0.6em auto;
+}
+
+.retry-submit {
+  background-color: #16425d;
+  border-color: #286aa7;
 }

--- a/CSS/course_Contents.css
+++ b/CSS/course_Contents.css
@@ -109,6 +109,79 @@ section {
   gap: 0.5em;
 }
 
+.continue-learning-panel {
+  width: min(74rem, calc(100% - 2rem));
+  margin: 0 auto 1.5rem;
+  padding: 1.5rem;
+  justify-content: space-between;
+  align-items: center;
+  border: 1px solid rgba(111, 219, 240, 0.24);
+  border-radius: 1.25rem;
+  background:
+    linear-gradient(135deg, rgba(9, 21, 34, 0.96), rgba(20, 54, 82, 0.84)),
+    rgba(0, 0, 0, 0.92);
+  box-shadow: 0 1rem 3rem rgba(0, 0, 0, 0.28);
+}
+
+.continue-learning-copy {
+  max-width: 44rem;
+}
+
+.continue-learning-kicker {
+  margin: 0 0 0.35rem;
+  color: #6fdbf0;
+  text-transform: uppercase;
+  letter-spacing: 0.18em;
+  font-size: 0.78rem;
+}
+
+.continue-learning-copy h2 {
+  margin: 0 0 0.5rem;
+}
+
+.continue-learning-summary {
+  margin: 0.5rem 0;
+}
+
+.continue-learning-stats {
+  display: flex;
+  gap: 1.5rem;
+  flex-wrap: wrap;
+}
+
+.continue-learning-stats p {
+  margin: 0.35rem 0;
+}
+
+.continue-learning-actions {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  align-items: flex-start;
+}
+
+.continue-learning-cta,
+.continue-learning-reset {
+  border: 0;
+  border-radius: 999px;
+  padding: 0.8rem 1.2rem;
+  font-size: 1rem;
+  cursor: pointer;
+}
+
+.continue-learning-cta {
+  background: #6fdbf0;
+  color: #091522;
+  text-decoration: none;
+  font-weight: 700;
+}
+
+.continue-learning-reset {
+  background: transparent;
+  color: #ffffff;
+  border: 1px solid rgba(255, 255, 255, 0.24);
+}
+
 .course-card {
   width: 22em;
   background-color: rgb(17, 25, 35);
@@ -170,6 +243,20 @@ section {
 @media only screen and (max-width: 600px) {
   header {
     position: static;
+  }
+
+  .continue-learning-panel {
+    padding: 1.2rem;
+  }
+
+  .continue-learning-actions {
+    width: 100%;
+  }
+
+  .continue-learning-cta,
+  .continue-learning-reset {
+    width: 100%;
+    text-align: center;
   }
 }
 .course-card {

--- a/HTML/Courses and Activities/Course 3/TAandSEquizcourse3.html
+++ b/HTML/Courses and Activities/Course 3/TAandSEquizcourse3.html
@@ -243,7 +243,7 @@
           </li>
         </ul>
 
-        <button onclick="submitQuiz()" class="submit">Submit Quiz</button>
+        <button class="submit">Submit Quiz</button>
 
         <p id="result"></p>
 
@@ -363,125 +363,24 @@
         <p>&copy; 2025 CyberMinds, Inc. All rights reserved.</p>
       </footer> -->
     </section>
+    <script src="../../../Javascript/header.js"></script>
+    <script src="../../../Javascript/footer.js"></script>
+    <script src="../../../Javascript/popUp.js"></script>
+    <script src="../../../Javascript/progress.js"></script>
+    <script src="../../../Javascript/quiz-engine.js"></script>
     <script>
-      function submitQuiz() {
-        var score = 0;
-
-        // Check answer for question 1
-        var q1Answer = document.querySelector('input[name="q1"]:checked');
-        if (q1Answer && q1Answer.value === 'ES') {
-          score++;
-        }
-        var lab = document.getElementById('q1-a1');
-        showAnswerDetail('q1-SW-detail');
-        lab.style.color = 'red';
-        lab = document.getElementById('q1-a2');
-        showAnswerDetail('q1-ES-detail');
-        lab.style.color = 'lightgreen';
-        lab = document.getElementById('q1-a3');
-        showAnswerDetail('q1-VW-detail');
-        lab.style.color = 'red';
-        lab = document.getElementById('q1-a4');
-        showAnswerDetail('q1-VS-detail');
-        lab.style.color = 'red';
-
-        // Check answer for question 2
-        var q2Answer = document.querySelector('input[name="q2"]:checked');
-        if (q2Answer && q2Answer.value === 'ignore') {
-          score++;
-        }
-        lab = document.getElementById('q2-a1');
-        showAnswerDetail('q2-open-detail');
-        lab.style.color = 'red';
-        lab = document.getElementById('q2-a2');
-        showAnswerDetail('q2-grammar-detail');
-        lab.style.color = 'red';
-        lab = document.getElementById('q2-a3');
-        showAnswerDetail('q2-verify-detail');
-        lab.style.color = 'red';
-        lab = document.getElementById('q2-a4');
-        showAnswerDetail('q2-ignore-detail');
-        lab.style.color = 'lightgreen';
-
-        var q3Answer = document.querySelector('input[name="q3"]:checked');
-        if (q3Answer && q3Answer.value === 'a1') {
-          score++;
-        }
-        lab = document.getElementById('q3-a1l');
-        showAnswerDetail('q3-a1-detail');
-        lab.style.color = 'lightgreen';
-        lab = document.getElementById('q3-a2l');
-        showAnswerDetail('q3-a2-detail');
-        lab.style.color = 'red';
-        lab = document.getElementById('q3-a3l');
-        showAnswerDetail('q3-a3-detail');
-        lab.style.color = 'red';
-        lab = document.getElementById('q3-a4l');
-        showAnswerDetail('q3-a4-detail');
-        lab.style.color = 'red';
-
-        var q4Answer = document.querySelector('input[name="q4"]:checked');
-        if (q4Answer && q4Answer.value === 'phishing') {
-          score++;
-        }
-        lab = document.getElementById('q4-a1');
-        showAnswerDetail('q4-tail-detail');
-        lab.style.color = 'red';
-        lab = document.getElementById('q4-a2');
-        showAnswerDetail('q4-dive-detail');
-        lab.style.color = 'red';
-        lab = document.getElementById('q4-a3');
-        showAnswerDetail('q4-phishing-detail');
-        lab.style.color = 'lightgreen';
-        lab = document.getElementById('q4-a4');
-        showAnswerDetail('q4-none-detail');
-        lab.style.color = 'red';
-
-        // Display the result
-        var resultElement = document.getElementById('result');
-        var labels = document.querySelectorAll('label');
-        var question = document.querySelectorAll('question');
-        resultElement.innerHTML = 'Your score is: ' + score + '/4';
-      }
-
-      function showAnswerDetail(detailId) {
-        var detailElement = document.getElementById(detailId);
-        if (detailElement) {
-          detailElement.style.display = 'block';
-
-          labels.forEach(function (label) {
-            label.style.width = '80%';
-          });
-        }
-      }
-
-      var labels = document.querySelectorAll('label');
-      labels.forEach(function (label) {
-        label.addEventListener('click', function () {
-          // Remove 'selected' class from all labels
-          labels.forEach(function (otherLabel) {
-            var radioLabel = label.closest('li.option'); // Assuming the radio is wrapped in an <li> with class "option"
-            var radioName = radioLabel
-              .querySelector('input[type="radio"]')
-              .getAttribute('name');
-            var otherRadioLabel = otherLabel.closest('li.option'); // Assuming the radio is wrapped in an <li> with class "option"
-            var otherRadioName = otherRadioLabel
-              .querySelector('input[type="radio"]')
-              .getAttribute('name');
-            if (otherRadioName === radioName) {
-              otherLabel.classList.remove('selected');
-            }
-          });
-
-          // Add 'selected' class to the clicked label
-          label.classList.add('selected');
-        });
+      window.CyberMindsQuizEngine.init({
+        quizId: 'course-3-threat-actors-social-engineering',
+        allowRetry: true,
+        explanationMode: 'final',
+        questions: [
+          { name: 'q1', correctValue: 'ES' },
+          { name: 'q2', correctValue: 'ignore' },
+          { name: 'q3', correctValue: 'a1' },
+          { name: 'q4', correctValue: 'phishing' },
+        ],
       });
     </script>
-<script src="../../../Javascript/footer.js"></script>
-<script src="../../../Javascript/header.js"></script>
-<script src="../../../Javascript/popUp.js"></script>
-    <script src="../../../Javascript/footer.js"></script>
     <script>
       (function () {
         if (!window.chatbase || window.chatbase('getState') !== 'initialized') {
@@ -517,4 +416,3 @@
     <script src="../../../Javascript/analytics.js"></script>
   </body>
 </html>
-

--- a/HTML/Courses and Activities/Course 4/TechnicalDefenseQUIZ.html
+++ b/HTML/Courses and Activities/Course 4/TechnicalDefenseQUIZ.html
@@ -40,7 +40,9 @@
             <input type="radio" name="q1" value="SW" id="q1-SW" />
             <label for="q1-SW" id="q1-a1">
               Standards of Information and Event Management
-              <div id="q1-SW-detail" class="answer-detail"></div>
+              <div id="q1-SW-detail" class="answer-detail">
+                Close, but SIEM starts with Security, not Standards.
+              </div>
             </label>
           </li>
           <li class="option">
@@ -54,14 +56,20 @@
             <input type="radio" name="q1" value="VW" id="q1-VW" />
             <label for="q1-VW" id="q1-a3">
               Social Inducement and Engineering Methods
-              <div id="q1-VW-detail" class="answer-detail"></div>
+              <div id="q1-VW-detail" class="answer-detail">
+                This expands to social engineering concepts, not security event
+                monitoring.
+              </div>
             </label>
           </li>
           <li class="option">
             <input type="radio" name="q1" value="VS" id="q1-VS" />
             <label for="q1-VS" id="q1-a4">
               Systems of Information and Engineering Methods
-              <div id="q1-VS-detail" class="answer-detail"></div>
+              <div id="q1-VS-detail" class="answer-detail">
+                SIEM platforms collect and analyze security telemetry; this
+                option does not reflect that purpose.
+              </div>
             </label>
           </li>
         </ul>
@@ -122,7 +130,11 @@
             <input type="radio" name="q3" value="true" id="q3-true" />
             <label for="q3-true" name="q3" id="q3-a1">
               True
-              <div id="q3-true-detail" class="answer-detail"></div>
+              <div id="q3-true-detail" class="answer-detail">
+                Writing your own scripts can help with customization, but the
+                security outcome depends on design and maintenance, not on
+                whether a tool is custom.
+              </div>
             </label>
           </li>
           <li class="option">
@@ -148,7 +160,10 @@
             <input type="radio" name="q4" value="tail" id="q4-tail" />
             <label for="q4-tail" name="q4" id="q4-a1">
               HTML and CSS
-              <div id="q4-tail-detail" class="answer-detail"></div>
+              <div id="q4-tail-detail" class="answer-detail">
+                HTML and CSS define presentation, not security automation
+                workflows.
+              </div>
             </label>
           </li>
           <li class="option">
@@ -169,12 +184,15 @@
             <input type="radio" name="q4" value="none" id="q4-none" />
             <label for="q4-none" name="q4" id="q4-a4">
               SQL
-              <div id="q4-none-detail" class="answer-detail"></div>
+              <div id="q4-none-detail" class="answer-detail">
+                SQL is useful for querying data, but Python and Bash are more
+                common choices for automation tasks in security operations.
+              </div>
             </label>
           </li>
         </ul>
 
-        <button onclick="submitQuiz()" class="submit">Submit Quiz</button>
+        <button class="submit">Submit Quiz</button>
 
         <p id="result"></p>
 
@@ -279,120 +297,24 @@
         <p>&copy; 2025 CyberMinds, Inc. All rights reserved.</p>
       </footer> -->
     </section>
+    <script src="../../../Javascript/header.js"></script>
+    <script src="../../../Javascript/footer.js"></script>
+    <script src="../../../Javascript/popUp.js"></script>
+    <script src="../../../Javascript/progress.js"></script>
+    <script src="../../../Javascript/quiz-engine.js"></script>
     <script>
-      function submitQuiz() {
-        var score = 0;
-
-        // Check answer for question 1
-        var q1Answer = document.querySelector('input[name="q1"]:checked');
-        if (q1Answer && q1Answer.value === 'ES') {
-          score++;
-        }
-        var lab = document.getElementById('q1-a1');
-        showAnswerDetail('q1-SW-detail');
-        lab.style.color = 'red';
-        lab = document.getElementById('q1-a2');
-        showAnswerDetail('q1-ES-detail');
-        lab.style.color = 'lightgreen';
-        lab = document.getElementById('q1-a3');
-        showAnswerDetail('q1-VW-detail');
-        lab.style.color = 'red';
-        lab = document.getElementById('q1-a4');
-        showAnswerDetail('q1-VS-detail');
-        lab.style.color = 'red';
-
-        // Check answer for question 2
-        var q2Answer = document.querySelector('input[name="q2"]:checked');
-        if (q2Answer && q2Answer.value === 'ignore') {
-          score++;
-        }
-        lab = document.getElementById('q2-a1');
-        showAnswerDetail('q2-open-detail');
-        lab.style.color = 'red';
-        lab = document.getElementById('q2-a2');
-        showAnswerDetail('q2-grammar-detail');
-        lab.style.color = 'red';
-        lab = document.getElementById('q2-a3');
-        showAnswerDetail('q2-verify-detail');
-        lab.style.color = 'red';
-        lab = document.getElementById('q2-a4');
-        showAnswerDetail('q2-ignore-detail');
-        lab.style.color = 'lightgreen';
-
-        var q3Answer = document.querySelector('input[name="q3"]:checked');
-        if (q3Answer && q3Answer.value === 'false') {
-          score++;
-        }
-        lab = document.getElementById('q3-a1');
-        showAnswerDetail('q3-true-detail');
-        lab.style.color = 'red';
-        lab = document.getElementById('q3-a2');
-        showAnswerDetail('q3-false-detail');
-        lab.style.color = 'lightgreen';
-
-        var q4Answer = document.querySelector('input[name="q4"]:checked');
-        if (
-          (q4Answer && q4Answer.value === 'dive') ||
-          (q4Answer && q4Answer.value === 'phishing')
-        ) {
-          score++;
-        }
-        lab = document.getElementById('q4-a1');
-        showAnswerDetail('q4-tail-detail');
-        lab.style.color = 'red';
-        lab = document.getElementById('q4-a2');
-        showAnswerDetail('q4-dive-detail');
-        lab.style.color = 'lightgreen';
-        lab = document.getElementById('q4-a3');
-        showAnswerDetail('q4-phishing-detail');
-        lab.style.color = 'lightgreen';
-        lab = document.getElementById('q4-a4');
-        showAnswerDetail('q4-none-detail');
-        lab.style.color = 'red';
-
-        // Display the result
-        var resultElement = document.getElementById('result');
-        resultElement.innerHTML = 'Your score is: ' + score + '/4';
-      }
-
-      function showAnswerDetail(detailId) {
-        var labels = document.querySelectorAll('label');
-        var detailElement = document.getElementById(detailId);
-        if (detailElement) {
-          detailElement.style.display = 'block';
-        }
-        labels.forEach(function (label) {
-          label.style.width = '80%';
-        });
-      }
-
-      var labels = document.querySelectorAll('label');
-      labels.forEach(function (label) {
-        label.addEventListener('click', function () {
-          // Remove 'selected' class from all labels
-          labels.forEach(function (otherLabel) {
-            var radioLabel = label.closest('li.option'); // Assuming the radio is wrapped in an <li> with class "option"
-            var radioName = radioLabel
-              .querySelector('input[type="radio"]')
-              .getAttribute('name');
-            var otherRadioLabel = otherLabel.closest('li.option'); // Assuming the radio is wrapped in an <li> with class "option"
-            var otherRadioName = otherRadioLabel
-              .querySelector('input[type="radio"]')
-              .getAttribute('name');
-            if (otherRadioName === radioName) {
-              otherLabel.classList.remove('selected');
-            }
-          });
-
-          // Add 'selected' class to the clicked label
-          label.classList.add('selected');
-        });
+      window.CyberMindsQuizEngine.init({
+        quizId: 'course-4-technical-measures-quiz',
+        allowRetry: true,
+        explanationMode: 'final',
+        questions: [
+          { name: 'q1', correctValue: 'ES' },
+          { name: 'q2', correctValue: 'ignore' },
+          { name: 'q3', correctValue: 'false' },
+          { name: 'q4', correctValues: ['dive', 'phishing'] },
+        ],
       });
     </script>
-<script src="../../../Javascript/footer.js"></script>
-<script src="../../../Javascript/header.js"></script>
-<script src="../../../Javascript/popUp.js"></script>
-    <script src="../../../Javascript/footer.js"></script>
     <script>
       (function () {
         if (!window.chatbase || window.chatbase('getState') !== 'initialized') {
@@ -428,4 +350,3 @@
     <script src="../../../Javascript/analytics.js"></script>
   </body>
 </html>
-

--- a/HTML/course_Contents.html
+++ b/HTML/course_Contents.html
@@ -37,6 +37,51 @@ If you are working on this please ask for the cybersecurity word doc content (Th
     </header>
     <p class="page-title">Courses</p>
 
+    <section
+      class="continue-learning-panel"
+      id="continueLearningPanel"
+      aria-label="Continue learning"
+    >
+      <div class="continue-learning-copy">
+        <p class="continue-learning-kicker">Continue learning</p>
+        <h2>Pick up from your local progress on this device.</h2>
+        <p class="continue-learning-summary">
+          Last visited lesson:
+          <span id="continueLearningLastVisited">No course progress yet</span>
+        </p>
+        <div class="continue-learning-stats">
+          <p>Completed quizzes: <span id="continueLearningQuizCount">0</span></p>
+          <p>Completed CTFs: <span id="continueLearningCtfCount">0</span></p>
+        </div>
+        <p class="continue-learning-summary">
+          Recommended next step:
+          <a
+            id="continueLearningRecommendationLink"
+            href="../HTML/Courses and Activities/Course 1/Introductioncourse1.html"
+          >
+            <span id="continueLearningRecommendation"
+              >Course 1 - Introduction</span
+            >
+          </a>
+        </p>
+      </div>
+      <div class="continue-learning-actions">
+        <a
+          id="continueLearningLink"
+          class="continue-learning-cta"
+          href="../HTML/Courses and Activities/Course 1/Introductioncourse1.html"
+          >Start your first lesson</a
+        >
+        <button
+          id="progressResetBtn"
+          class="continue-learning-reset"
+          type="button"
+        >
+          Reset local progress
+        </button>
+      </div>
+    </section>
+
     <section>
       <!-- Course 1 -->
       <a
@@ -292,6 +337,7 @@ If you are working on this please ask for the cybersecurity word doc content (Th
     <script src="../Javascript/header.js"></script>
     <script src="../Javascript/popUp_Courses.js"></script>
     <script src="../Javascript/footer.js"></script>
+    <script src="../Javascript/progress.js"></script>
     <script src="../Javascript/analytics.js"></script>
   </body>
 </html>

--- a/Javascript/header.js
+++ b/Javascript/header.js
@@ -11,6 +11,7 @@ const navItems = [
 ];
 
 const SHARED_HEADER_STYLE_ID = 'cmh-shared-styles';
+const SHARED_PROGRESS_SCRIPT_ID = 'cm-progress-script';
 
 function ensureSharedHeaderStyles() {
   if (document.getElementById(SHARED_HEADER_STYLE_ID)) {
@@ -221,6 +222,17 @@ function joinBasePath(basePath, relativePath) {
   return `${cleanBase}/${cleanRelative}`;
 }
 
+function ensureProgressScript(basePath) {
+  if (document.getElementById(SHARED_PROGRESS_SCRIPT_ID)) {
+    return;
+  }
+
+  const script = document.createElement('script');
+  script.id = SHARED_PROGRESS_SCRIPT_ID;
+  script.src = joinBasePath(basePath, 'Javascript/progress.js');
+  document.head.appendChild(script);
+}
+
 function renderHeader() {
   let header = document.getElementById('site-header');
   if (!header) {
@@ -238,6 +250,7 @@ function renderHeader() {
   ensureSharedHeaderStyles();
 
   const basePath = getBasePath();
+  ensureProgressScript(basePath);
   const adjustedNav = navItems.map((item) => ({
     ...item,
     href: joinBasePath(basePath, item.href)

--- a/Javascript/progress.js
+++ b/Javascript/progress.js
@@ -1,0 +1,353 @@
+/**
+ * @file Frontend-only learner progress tracking for no-sign-in flows.
+ *
+ * Stores only safe local identifiers in localStorage. No names, answers,
+ * prompts, or personal identifiers are persisted.
+ */
+(function attachLearnerProgress(global) {
+  if (global.CyberMindsProgress) {
+    return;
+  }
+
+  var STORAGE_KEY = 'cm_learning_progress_v1';
+  var CTF_STORAGE_KEY = 'cm_ctf_progress_v1';
+  var DEFAULT_RESUME = {
+    id: 'course-1-introduction',
+    title: 'Course 1 - Introduction',
+    href: '/HTML/Courses and Activities/Course 1/Introductioncourse1.html',
+    type: 'course-page',
+  };
+  var RECOMMENDATIONS = {
+    'course-3-social-engineering': {
+      id: 'course-3-threat-actors-social-engineering',
+      title: 'Threat Actors and Social Engineering Quiz',
+      href: '/HTML/Courses and Activities/Course 3/TAandSEquizcourse3.html',
+      type: 'quiz',
+    },
+    'course-4-automationwithpythoncourse4': {
+      id: 'course-4-technical-measures-quiz',
+      title: 'Course 4 - Technical Measures Quiz',
+      href: '/HTML/Courses and Activities/Course 4/TechnicalDefenseQUIZ.html',
+      type: 'quiz',
+    },
+  };
+
+  function getRecommendationKey(lastVisited) {
+    if (!lastVisited) {
+      return '';
+    }
+
+    if (RECOMMENDATIONS[lastVisited.id]) {
+      return lastVisited.id;
+    }
+
+    if (/SocialEngineeringcourse3\.html$/i.test(lastVisited.href || '')) {
+      return 'course-3-social-engineering';
+    }
+
+    if (/AutomationwithPythoncourse4\.html$/i.test(lastVisited.href || '')) {
+      return 'course-4-automationwithpythoncourse4';
+    }
+
+    return '';
+  }
+
+  function defaultState() {
+    return {
+      lastVisited: null,
+      visitedPages: {},
+      completedQuizzes: {},
+    };
+  }
+
+  function sanitizeSegment(segment) {
+    return String(segment || '')
+      .toLowerCase()
+      .replace(/\.html?$/, '')
+      .replace(/[^a-z0-9]+/g, '-')
+      .replace(/^-+|-+$/g, '');
+  }
+
+  function normalizeHref(href) {
+    if (!href) {
+      return '/';
+    }
+
+    try {
+      return new URL(href, global.location.origin).pathname;
+    } catch (error) {
+      return String(href);
+    }
+  }
+
+  function readState() {
+    try {
+      var raw = global.localStorage.getItem(STORAGE_KEY);
+      if (!raw) {
+        return defaultState();
+      }
+
+      var parsed = JSON.parse(raw);
+      if (!parsed || typeof parsed !== 'object') {
+        return defaultState();
+      }
+
+      return {
+        lastVisited:
+          parsed.lastVisited && typeof parsed.lastVisited === 'object'
+            ? parsed.lastVisited
+            : null,
+        visitedPages:
+          parsed.visitedPages && typeof parsed.visitedPages === 'object'
+            ? parsed.visitedPages
+            : {},
+        completedQuizzes:
+          parsed.completedQuizzes && typeof parsed.completedQuizzes === 'object'
+            ? parsed.completedQuizzes
+            : {},
+      };
+    } catch (error) {
+      return defaultState();
+    }
+  }
+
+  function writeState(state) {
+    try {
+      global.localStorage.setItem(STORAGE_KEY, JSON.stringify(state));
+    } catch (error) {
+      // Storage can be disabled or full. Progress UI should still render.
+    }
+  }
+
+  function readCtfProgress() {
+    try {
+      var raw = global.localStorage.getItem(CTF_STORAGE_KEY);
+      if (!raw) {
+        return {};
+      }
+
+      var parsed = JSON.parse(raw);
+      return parsed && typeof parsed === 'object' ? parsed : {};
+    } catch (error) {
+      return {};
+    }
+  }
+
+  function isSafeInternalHref(href) {
+    var normalized = normalizeHref(href);
+    var decoded = normalized;
+    try {
+      decoded = decodeURIComponent(normalized);
+    } catch (error) {
+      decoded = normalized;
+    }
+
+    return (
+      decoded.indexOf('/HTML/Courses and Activities/') === 0 ||
+      normalized.indexOf('/HTML/terminal/index.html') === 0 ||
+      normalized === '/HTML/CTF.html'
+    );
+  }
+
+  function toSafeHref(href, fallbackHref) {
+    return isSafeInternalHref(href) ? normalizeHref(href) : fallbackHref;
+  }
+
+  function derivePageMeta() {
+    var path = normalizeHref(global.location.pathname);
+    var query = new URLSearchParams(global.location.search);
+    var challengeId = query.get('challenge');
+    var pageTitleElement = global.document.querySelector('.page-title');
+    var title = global.document.title || (pageTitleElement && pageTitleElement.textContent) || 'CyberMinds';
+    title = String(title).trim();
+
+    if (challengeId) {
+      return {
+        id: 'ctf-' + sanitizeSegment(challengeId),
+        title,
+        href: toSafeHref(path + global.location.search, '/HTML/CTF.html'),
+        type: 'ctf-challenge',
+      };
+    }
+
+    if (path.indexOf('/HTML/Courses and Activities/') !== -1) {
+      var segments = path.split('/');
+      var courseSegment = sanitizeSegment(segments[segments.length - 2]);
+      var pageSegment = sanitizeSegment(segments[segments.length - 1]);
+      var type = pageSegment.indexOf('quiz') !== -1 ? 'quiz' : 'course-page';
+
+      return {
+        id: courseSegment + '-' + pageSegment,
+        title,
+        href: toSafeHref(path, DEFAULT_RESUME.href),
+        type,
+      };
+    }
+
+    if (path.indexOf('/HTML/CTF.html') !== -1) {
+      return {
+        id: 'ctf-catalog',
+        title,
+        href: toSafeHref(path, '/HTML/CTF.html'),
+        type: 'ctf-catalog',
+      };
+    }
+
+    return null;
+  }
+
+  function trackCurrentPage() {
+    var meta = derivePageMeta();
+    if (!meta || (meta.type !== 'course-page' && meta.type !== 'quiz' && meta.type !== 'ctf-challenge')) {
+      return;
+    }
+
+    var state = readState();
+    var record = {
+      id: meta.id,
+      title: meta.title,
+      href: toSafeHref(meta.href, DEFAULT_RESUME.href),
+      type: meta.type,
+      visitedAt: new Date().toISOString(),
+    };
+
+    state.lastVisited = record;
+    state.visitedPages[meta.id] = record;
+    writeState(state);
+  }
+
+  function markQuizComplete(quizId, payload) {
+    if (!quizId) {
+      return;
+    }
+
+    var state = readState();
+    state.completedQuizzes[quizId] = {
+      score: Number(payload.score) || 0,
+      totalQuestions: Number(payload.totalQuestions) || 0,
+      completedAt: new Date().toISOString(),
+    };
+    writeState(state);
+
+    if (typeof global.trackEvent === 'function') {
+      global.trackEvent('quiz_complete', {
+        quiz: quizId,
+        score: Number(payload.score) || 0,
+        total_questions: Number(payload.totalQuestions) || 0,
+      });
+    }
+  }
+
+  function getRecommendation(state) {
+    var lastVisited = state.lastVisited;
+    var recommendationKey = getRecommendationKey(lastVisited);
+
+    if (
+      recommendationKey &&
+      RECOMMENDATIONS[recommendationKey] &&
+      !state.completedQuizzes[RECOMMENDATIONS[recommendationKey].id]
+    ) {
+      return RECOMMENDATIONS[recommendationKey];
+    }
+
+    if (lastVisited) {
+      return {
+        id: lastVisited.id,
+        title: 'Resume ' + lastVisited.title,
+        href: toSafeHref(lastVisited.href, DEFAULT_RESUME.href),
+        type: lastVisited.type,
+      };
+    }
+
+    return DEFAULT_RESUME;
+  }
+
+  function getSummary() {
+    var state = readState();
+    var ctfProgress = readCtfProgress();
+    var completedQuizCount = Object.keys(state.completedQuizzes).length;
+    var completedCtfCount = Object.keys(ctfProgress).filter(function (key) {
+      return !!ctfProgress[key];
+    }).length;
+
+    return {
+      state,
+      lastVisited: state.lastVisited,
+      completedQuizCount,
+      completedCtfCount,
+      recommendation: getRecommendation(state),
+    };
+  }
+
+  function renderDashboard() {
+    var panel = global.document.getElementById('continueLearningPanel');
+    if (!panel) {
+      return;
+    }
+
+    var summary = getSummary();
+    var resumeLink = global.document.getElementById('continueLearningLink');
+    var lastVisited = global.document.getElementById('continueLearningLastVisited');
+    var quizCount = global.document.getElementById('continueLearningQuizCount');
+    var ctfCount = global.document.getElementById('continueLearningCtfCount');
+    var recommendation = global.document.getElementById('continueLearningRecommendation');
+    var recommendationLink = global.document.getElementById('continueLearningRecommendationLink');
+    var resetButton = global.document.getElementById('progressResetBtn');
+
+    if (summary.lastVisited) {
+      resumeLink.setAttribute(
+        'href',
+        toSafeHref(summary.lastVisited.href, DEFAULT_RESUME.href)
+      );
+      resumeLink.textContent = 'Resume where you left off';
+      lastVisited.textContent = summary.lastVisited.title;
+    } else {
+      resumeLink.setAttribute('href', DEFAULT_RESUME.href);
+      resumeLink.textContent = 'Start your first lesson';
+      lastVisited.textContent = 'No course progress yet';
+    }
+
+    quizCount.textContent = String(summary.completedQuizCount);
+    ctfCount.textContent = String(summary.completedCtfCount);
+    recommendation.textContent = summary.recommendation.title;
+    recommendationLink.setAttribute(
+      'href',
+      toSafeHref(summary.recommendation.href, DEFAULT_RESUME.href)
+    );
+
+    if (resetButton && !resetButton.dataset.bound) {
+      resetButton.dataset.bound = 'true';
+      resetButton.addEventListener('click', function () {
+        if (!global.confirm('Reset your local course, quiz, and CTF progress on this device?')) {
+          return;
+        }
+
+        try {
+          global.localStorage.removeItem(STORAGE_KEY);
+          global.localStorage.removeItem(CTF_STORAGE_KEY);
+        } catch (error) {
+          // Ignore storage failures so the UI can still refresh.
+        }
+        renderDashboard();
+      });
+    }
+  }
+
+  function init() {
+    trackCurrentPage();
+    renderDashboard();
+  }
+
+  global.CyberMindsProgress = {
+    markQuizComplete,
+    getSummary,
+    renderDashboard,
+    STORAGE_KEY,
+  };
+
+  if (global.document.readyState === 'loading') {
+    global.document.addEventListener('DOMContentLoaded', init);
+  } else {
+    init();
+  }
+})(window);

--- a/Javascript/quiz-engine.js
+++ b/Javascript/quiz-engine.js
@@ -1,0 +1,157 @@
+/**
+ * @file Shared multiple-choice quiz engine for CyberMinds.
+ */
+(function attachQuizEngine(global) {
+  function getCorrectValues(question) {
+    if (Array.isArray(question.correctValues) && question.correctValues.length) {
+      return question.correctValues;
+    }
+
+    return [question.correctValue];
+  }
+
+  function toggleLabelSelection(input) {
+    var labels = global.document.querySelectorAll(
+      'label[for][for^="' + input.name + '-"]'
+    );
+    labels.forEach(function (label) {
+      label.classList.remove('selected');
+    });
+
+    var activeLabel = global.document.querySelector('label[for="' + input.id + '"]');
+    if (activeLabel) {
+      activeLabel.classList.add('selected');
+    }
+  }
+
+  function ensureRetryButton(submitButton) {
+    var existing = global.document.getElementById('retryQuizBtn');
+    if (existing) {
+      return existing;
+    }
+
+    var retryButton = global.document.createElement('button');
+    retryButton.type = 'button';
+    retryButton.id = 'retryQuizBtn';
+    retryButton.className = 'submit retry-submit';
+    retryButton.textContent = 'Retry Quiz';
+    retryButton.style.display = 'none';
+    submitButton.insertAdjacentElement('afterend', retryButton);
+    return retryButton;
+  }
+
+  function showExplanation(label) {
+    var detail = label.querySelector('.answer-detail');
+    if (detail) {
+      detail.style.display = 'block';
+    }
+  }
+
+  function resetQuestionState(questionNames) {
+    questionNames.forEach(function (name) {
+      global.document
+        .querySelectorAll('input[name="' + name + '"]')
+        .forEach(function (input) {
+          input.checked = false;
+        });
+
+      global.document
+        .querySelectorAll('input[name="' + name + '"] + label, label[for^="' + name + '-"]')
+        .forEach(function (label) {
+          label.classList.remove('selected', 'is-correct', 'is-incorrect');
+          label.style.width = '';
+          var detail = label.querySelector('.answer-detail');
+          if (detail) {
+            detail.style.display = 'none';
+          }
+        });
+    });
+  }
+
+  function init(config) {
+    var resultElement = global.document.getElementById(config.resultElementId || 'result');
+    var submitButton = global.document.querySelector(config.submitSelector || '.submit');
+    if (!resultElement || !submitButton || !Array.isArray(config.questions)) {
+      return;
+    }
+
+    submitButton.type = 'button';
+    resultElement.setAttribute('aria-live', 'polite');
+    var retryButton = ensureRetryButton(submitButton);
+    var questionNames = config.questions.map(function (question) {
+      return question.name;
+    });
+
+    config.questions.forEach(function (question) {
+      global.document
+        .querySelectorAll('input[name="' + question.name + '"]')
+        .forEach(function (input) {
+          input.addEventListener('change', function () {
+            toggleLabelSelection(input);
+
+            if (config.explanationMode === 'immediate') {
+              var label = global.document.querySelector('label[for="' + input.id + '"]');
+              if (label) {
+                showExplanation(label);
+              }
+            }
+          });
+        });
+    });
+
+    retryButton.addEventListener('click', function () {
+      resetQuestionState(questionNames);
+      retryButton.style.display = 'none';
+      resultElement.textContent = '';
+      submitButton.style.display = '';
+      submitButton.focus();
+    });
+
+    submitButton.addEventListener('click', function () {
+      var score = 0;
+
+      config.questions.forEach(function (question) {
+        var correctValues = getCorrectValues(question);
+        var selected = global.document.querySelector(
+          'input[name="' + question.name + '"]:checked'
+        );
+
+        global.document
+          .querySelectorAll('input[name="' + question.name + '"]')
+          .forEach(function (input) {
+            var label = global.document.querySelector('label[for="' + input.id + '"]');
+            if (!label) {
+              return;
+            }
+
+            label.style.width = '80%';
+            showExplanation(label);
+            label.classList.remove('is-correct', 'is-incorrect');
+            label.classList.add(
+              correctValues.indexOf(input.value) !== -1 ? 'is-correct' : 'is-incorrect'
+            );
+          });
+
+        if (selected && correctValues.indexOf(selected.value) !== -1) {
+          score += 1;
+        }
+      });
+
+      resultElement.textContent =
+        'Your score is: ' + score + '/' + config.questions.length;
+      submitButton.style.display = 'none';
+      retryButton.style.display = config.allowRetry ? '' : 'none';
+
+      if (global.CyberMindsProgress && typeof global.CyberMindsProgress.markQuizComplete === 'function') {
+        global.CyberMindsProgress.markQuizComplete(config.quizId, {
+          score,
+          totalQuestions: config.questions.length,
+        });
+      }
+    });
+  }
+
+  global.CyberMindsQuizEngine = {
+    init,
+  };
+})(window);

--- a/docs/QUIZ_ENGINE.md
+++ b/docs/QUIZ_ENGINE.md
@@ -1,0 +1,53 @@
+# Shared Quiz Engine
+
+CyberMinds quizzes can use `Javascript/quiz-engine.js` to keep scoring,
+explanations, retry behaviour, and local progress tracking consistent.
+
+## Required markup
+
+- Use grouped radio inputs with stable `name` values, one group per question.
+- Give each input a unique `id`.
+- Pair every input with a `<label for="...">`.
+- Put explanation copy inside a nested `<div class="answer-detail">...</div>`
+  inside the label.
+- Keep a result container with `id="result"`.
+- Keep a submit button with class `submit`.
+
+## Example
+
+```html
+<li class="option">
+  <input type="radio" name="q1" value="correct" id="q1-correct" />
+  <label for="q1-correct">
+    Correct answer
+    <div class="answer-detail">
+      Correct because this control blocks unauthorized access before execution.
+    </div>
+  </label>
+</li>
+```
+
+```html
+<script src="../../../Javascript/progress.js"></script>
+<script src="../../../Javascript/quiz-engine.js"></script>
+<script>
+  window.CyberMindsQuizEngine.init({
+    quizId: 'course-1-example-quiz',
+    allowRetry: true,
+    explanationMode: 'final',
+    questions: [
+      { name: 'q1', correctValue: 'correct' },
+      { name: 'q2', correctValue: 'false' },
+    ],
+  });
+</script>
+```
+
+## Behavior
+
+- Scores each question from the configured `correctValue`.
+- Reveals explanations after submission by default.
+- Supports retry without a page refresh.
+- Stores only safe local quiz IDs and score totals in
+  `localStorage['cm_learning_progress_v1']`.
+- Never sends selected answers or free-form learner input to analytics.

--- a/tests/smoke.spec.js
+++ b/tests/smoke.spec.js
@@ -186,6 +186,170 @@ test.describe('Navigation', () => {
   });
 });
 
+// ─── Learner progress ───────────────────────────────────────────────────────
+
+test.describe('Learner progress dashboard', () => {
+  test('course catalog shows local progress, recommendation, and reset flow', async ({
+    page,
+  }) => {
+    await page.addInitScript(() => {
+      window.localStorage.setItem(
+        'cm_learning_progress_v1',
+        JSON.stringify({
+          lastVisited: {
+            id: 'course-3-social-engineering',
+            title: 'Course 3 - Social Engineering',
+            href: '/HTML/Courses and Activities/Course 3/SocialEngineeringcourse3.html',
+            type: 'course-page',
+            visitedAt: '2026-06-21T12:00:00.000Z',
+          },
+          visitedPages: {
+            'course-3-introduction': {
+              id: 'course-3-introduction',
+              title: 'Course 3 - Introduction',
+              href: '/HTML/Courses and Activities/Course 3/Introductioncourse3.html',
+              type: 'course-page',
+              visitedAt: '2026-06-21T11:00:00.000Z',
+            },
+          },
+          completedQuizzes: {
+            'course-3-threat-actors-social-engineering': {
+              score: 4,
+              totalQuestions: 4,
+              completedAt: '2026-06-21T12:05:00.000Z',
+            },
+          },
+        })
+      );
+      window.localStorage.setItem(
+        'cm_ctf_progress_v1',
+        JSON.stringify({
+          'linux-basics': {
+            passed: true,
+            passedAt: '2026-06-21T12:10:00.000Z',
+          },
+        })
+      );
+    });
+
+    await page.goto('/HTML/course_Contents.html');
+
+    await expect(page.locator('#continueLearningPanel')).toBeVisible();
+    await expect(page.locator('#continueLearningLastVisited')).toContainText(
+      'Course 3 - Social Engineering'
+    );
+    await expect(page.locator('#continueLearningQuizCount')).toContainText('1');
+    await expect(page.locator('#continueLearningCtfCount')).toContainText('1');
+    await expect(page.locator('#continueLearningLink')).toHaveAttribute(
+      'href',
+      /SocialEngineeringcourse3\.html/
+    );
+    await expect(page.locator('#continueLearningRecommendation')).toContainText(
+      /Threat Actors and Social Engineering Quiz|resume/i
+    );
+
+    page.once('dialog', (dialog) => dialog.accept());
+    await page.locator('#progressResetBtn').click();
+
+    await expect(page.locator('#continueLearningQuizCount')).toContainText('0');
+    await expect(page.locator('#continueLearningCtfCount')).toContainText('0');
+    await expect(page.locator('#continueLearningLastVisited')).toContainText(
+      /No course progress yet/i
+    );
+  });
+
+  test('course catalog ignores unsafe persisted resume links', async ({
+    page,
+  }) => {
+    await page.addInitScript(() => {
+      window.localStorage.setItem(
+        'cm_learning_progress_v1',
+        JSON.stringify({
+          lastVisited: {
+            id: 'bad-link',
+            title: 'Injected link',
+            href: 'javascript:alert(1)',
+            type: 'course-page',
+            visitedAt: '2026-06-21T12:00:00.000Z',
+          },
+          visitedPages: {},
+          completedQuizzes: {},
+        })
+      );
+    });
+
+    await page.goto('/HTML/course_Contents.html');
+
+    await expect(page.locator('#continueLearningLink')).toHaveAttribute(
+      'href',
+      /Introductioncourse1\.html/
+    );
+  });
+});
+
+// ─── Shared quiz engine ─────────────────────────────────────────────────────
+
+test.describe('Shared quiz engine', () => {
+  test('migrated quiz shows explanations, score, and saves completion locally', async ({
+    page,
+  }) => {
+    await page.goto(
+      '/HTML/Courses and Activities/Course 3/TAandSEquizcourse3.html'
+    );
+
+    await page.locator('label[for="q1-ES"]').click();
+    await page.locator('label[for="q2-ignore"]').click();
+    await page.locator('label[for="q3-a1"]').click();
+    await page.locator('label[for="q4-phishing"]').click();
+    await page.getByRole('button', { name: /submit quiz/i }).click();
+
+    await expect(page.locator('#result')).toContainText('4/4');
+    await expect(page.locator('#q1-ES-detail')).toBeVisible();
+    await expect(page.locator('#q1-SW-detail')).toBeVisible();
+
+    const saved = await page.evaluate(() => {
+      const raw = window.localStorage.getItem('cm_learning_progress_v1');
+      return raw ? JSON.parse(raw) : null;
+    });
+
+    expect(saved.completedQuizzes).toHaveProperty(
+      'course-3-threat-actors-social-engineering'
+    );
+    expect(
+      saved.completedQuizzes['course-3-threat-actors-social-engineering'].score
+    ).toBe(4);
+  });
+
+  test('second migrated quiz supports alternate correct answer and retry', async ({
+    page,
+  }) => {
+    await page.goto(
+      '/HTML/Courses and Activities/Course 4/TechnicalDefenseQUIZ.html'
+    );
+
+    await page.locator('label[for="q1-ES"]').click();
+    await page.locator('label[for="q2-ignore"]').click();
+    await page.locator('label[for="q3-false"]').click();
+    await page.locator('label[for="q4-phishing"]').click();
+    await page.getByRole('button', { name: /submit quiz/i }).click();
+
+    await expect(page.locator('#result')).toContainText('4/4');
+
+    const saved = await page.evaluate(() => {
+      const raw = window.localStorage.getItem('cm_learning_progress_v1');
+      return raw ? JSON.parse(raw) : null;
+    });
+
+    expect(saved.completedQuizzes).toHaveProperty(
+      'course-4-technical-measures-quiz'
+    );
+
+    await page.getByRole('button', { name: /retry quiz/i }).click();
+    await expect(page.locator('#result')).toHaveText('');
+    await expect(page.locator('#retryQuizBtn')).toBeHidden();
+  });
+});
+
 // ─── Mock terminal ───────────────────────────────────────────────────────────
 
 test.describe('Mock terminal', () => {


### PR DESCRIPTION
Adds a shared frontend quiz engine for migrated course quizzes and a no-sign-in learner progress dashboard on the course catalog. This removes duplicated scoring logic, adds explanation/retry support, and gives returning learners a concrete resume path using browser-local progress only.

Closes #137
Closes #138

## What changed
- adds `Javascript/quiz-engine.js` for shared quiz scoring, explanations, retry flow, and local quiz completion tracking
- adds `Javascript/progress.js` for frontend-only learner progress, safe localStorage handling, CTA sanitization, and course catalog resume/recommendation UI
- migrates the Course 3 and Course 4 quiz pages onto the shared engine and fills in missing explanation copy for the migrated Course 4 quiz
- documents the shared quiz HTML/config contract in `docs/QUIZ_ENGINE.md`
- extends Playwright smoke coverage for the learner progress panel, unsafe persisted links, and both migrated quizzes

## Testing
- `npm run lint:frontend`
- `npm run test:smoke`

## Review focus
- progress storage safety and resume/recommendation behavior on static course pages
- shared quiz engine behavior on migrated quizzes, especially multi-correct handling on Course 4
