### PR TITLE
feat(terminal): add OCI deploy and legacy quiz tracking

### DIFF
--- a/Javascript/progress.js
+++ b/Javascript/progress.js
@@ -198,6 +198,12 @@
 
   function derivePageMeta() {
     var path = normalizeHref(global.location.pathname);
+    var decodedPath = path;
+    try {
+      decodedPath = decodeURIComponent(path);
+    } catch (error) {
+      decodedPath = path;
+    }
     var query = new URLSearchParams(global.location.search);
     var challengeId = query.get('challenge');
     var pageTitleElement = global.document.querySelector('.page-title');
@@ -213,8 +219,8 @@
       };
     }
 
-    if (path.indexOf('/HTML/Courses and Activities/') !== -1) {
-      var segments = path.split('/');
+    if (decodedPath.indexOf('/HTML/Courses and Activities/') !== -1) {
+      var segments = decodedPath.split('/');
       var courseSegment = sanitizeSegment(segments[segments.length - 2]);
       var pageSegment = sanitizeSegment(segments[segments.length - 1]);
       var type = pageSegment.indexOf('quiz') !== -1 ? 'quiz' : 'course-page';
@@ -227,7 +233,7 @@
       };
     }
 
-    if (path.indexOf('/HTML/CTF.html') !== -1) {
+    if (decodedPath.indexOf('/HTML/CTF.html') !== -1) {
       return {
         id: 'ctf-catalog',
         title,
@@ -279,6 +285,41 @@
         total_questions: Number(payload.totalQuestions) || 0,
       });
     }
+  }
+
+  function initLegacyQuizTracking() {
+    var meta = derivePageMeta();
+    if (!meta || meta.type !== 'quiz') {
+      return;
+    }
+
+    var resultElement = global.document.getElementById('result');
+    if (!resultElement) {
+      return;
+    }
+
+    var persistFromResult = function () {
+      var text = String(resultElement.textContent || '').trim();
+      var match = text.match(/Your score is:\s*(\d+)\s*\/\s*(\d+)/i);
+      if (!match) {
+        return;
+      }
+
+      var quizId = global.document.body.dataset.quizId || meta.id;
+      markQuizComplete(quizId, {
+        score: Number(match[1]),
+        totalQuestions: Number(match[2]),
+      });
+    };
+
+    var observer = new MutationObserver(persistFromResult);
+    observer.observe(resultElement, {
+      childList: true,
+      characterData: true,
+      subtree: true,
+    });
+
+    persistFromResult();
   }
 
   function getRecommendation(state) {
@@ -375,6 +416,7 @@
 
   function init() {
     trackCurrentPage();
+    initLegacyQuizTracking();
     renderDashboard();
   }
 

--- a/Javascript/quiz-engine.js
+++ b/Javascript/quiz-engine.js
@@ -75,6 +75,7 @@
       return;
     }
 
+    global.document.body.dataset.quizId = config.quizId;
     submitButton.type = 'button';
     resultElement.setAttribute('aria-live', 'polite');
     var retryButton = ensureRetryButton(submitButton);

--- a/terminal/infra/oracle-free-tier/README.md
+++ b/terminal/infra/oracle-free-tier/README.md
@@ -1,0 +1,67 @@
+# Oracle Free Tier Terminal Deploy
+
+This Terraform config provisions a small OCI VM and bootstraps the CyberMinds
+terminal backend with Docker Compose and the existing production Caddy setup in
+`terminal/docker-compose.prod.yml`.
+
+## What it does
+
+- creates a VCN, public subnet, route table, internet gateway, and security
+  list
+- creates one public ARM instance on `VM.Standard.A1.Flex`
+- installs Docker and Git with cloud-init
+- clones `Cyber-Minds/cyber-minds.github.io`
+- writes `terminal/.env`
+- starts the terminal stack with the repo's production compose file
+
+## Why this fixes the current terminal outage
+
+The live frontend currently fails at terminal session creation because the
+browser rejects `https://terminal.egeuysal.com` with
+`ERR_CERT_AUTHORITY_INVALID`. This deployment path fixes that by standing up a
+fresh host where the compose stack's Caddy container can obtain a valid
+certificate for a real DNS hostname that points at the OCI VM.
+
+## Prerequisites
+
+1. Create an Oracle Cloud compartment and API key.
+2. Pick an Ubuntu image OCID for your target region.
+3. Point your terminal DNS name to the instance public IP after `terraform apply`.
+4. Use a domain that can obtain a public Let's Encrypt certificate.
+
+## Usage
+
+```bash
+cd terminal/infra/oracle-free-tier
+cp terraform.tfvars.example terraform.tfvars
+# fill in your OCI OCIDs, image OCID, SSH key path, and public domain
+
+terraform init
+terraform plan
+terraform apply
+```
+
+## After apply
+
+1. Create or update the DNS `A` record from `app_domain` to the output public IP.
+2. Wait a minute for DNS propagation.
+3. Re-run:
+
+```bash
+terraform apply
+```
+
+4. Verify:
+
+```bash
+curl -I https://<your-terminal-domain>/health
+```
+
+Expected: `HTTP/2 200`
+
+## Notes
+
+- The default `allowed_origins` is `https://cyber-minds.github.io`.
+- Oracle free tier capacity for `VM.Standard.A1.Flex` can be region-limited.
+- This config assumes you want the terminal backend only. It does not manage
+  the GitHub Pages frontend.

--- a/terminal/infra/oracle-free-tier/cloud-init.tftpl
+++ b/terminal/infra/oracle-free-tier/cloud-init.tftpl
@@ -1,0 +1,52 @@
+#cloud-config
+package_update: true
+package_upgrade: true
+
+packages:
+  - git
+  - docker.io
+
+write_files:
+  - path: /etc/systemd/system/cyberminds-terminal.service
+    permissions: "0644"
+    content: |
+      [Unit]
+      Description=CyberMinds terminal deployment
+      Requires=docker.service
+      After=docker.service network-online.target
+      Wants=network-online.target
+
+      [Service]
+      Type=oneshot
+      RemainAfterExit=yes
+      WorkingDirectory=${project_dir}/terminal
+      ExecStart=/usr/bin/docker compose -f docker-compose.prod.yml --env-file .env up -d --build
+      ExecStop=/usr/bin/docker compose -f docker-compose.prod.yml --env-file .env down
+
+      [Install]
+      WantedBy=multi-user.target
+
+runcmd:
+  - systemctl enable --now docker
+  - mkdir -p ${project_dir}
+  - |
+    if [ ! -d "${project_dir}/.git" ]; then
+      git clone --branch ${repo_branch} ${repo_url} ${project_dir}
+    else
+      cd ${project_dir}
+      git fetch --all --prune
+      git checkout ${repo_branch}
+      git reset --hard origin/${repo_branch}
+    fi
+  - |
+    cat > ${project_dir}/terminal/.env <<'EOF'
+    PORT=3000
+    ENVIRONMENT=production
+    APP_DOMAIN=${app_domain}
+    CADDY_HTTP_PORT=${caddy_http_port}
+    CADDY_HTTPS_PORT=${caddy_https_port}
+    ALLOWED_ORIGINS=${allowed_origins}
+    EOF
+  - systemctl daemon-reload
+  - systemctl enable cyberminds-terminal.service
+  - systemctl restart cyberminds-terminal.service

--- a/terminal/infra/oracle-free-tier/main.tf
+++ b/terminal/infra/oracle-free-tier/main.tf
@@ -1,0 +1,141 @@
+terraform {
+  required_version = ">= 1.5.0"
+
+  required_providers {
+    oci = {
+      source  = "oracle/oci"
+      version = ">= 6.0.0"
+    }
+  }
+}
+
+provider "oci" {
+  tenancy_ocid     = var.tenancy_ocid
+  user_ocid        = var.user_ocid
+  fingerprint      = var.fingerprint
+  private_key_path = var.private_key_path
+  region           = var.region
+}
+
+data "oci_identity_availability_domains" "ads" {
+  compartment_id = var.tenancy_ocid
+}
+
+resource "oci_core_vcn" "terminal" {
+  compartment_id = var.compartment_ocid
+  cidr_block     = var.vcn_cidr
+  display_name   = "${var.name_prefix}-vcn"
+  dns_label      = "termvcn"
+}
+
+resource "oci_core_internet_gateway" "terminal" {
+  compartment_id = var.compartment_ocid
+  vcn_id         = oci_core_vcn.terminal.id
+  display_name   = "${var.name_prefix}-igw"
+}
+
+resource "oci_core_route_table" "terminal" {
+  compartment_id = var.compartment_ocid
+  vcn_id         = oci_core_vcn.terminal.id
+  display_name   = "${var.name_prefix}-rt"
+
+  route_rules {
+    network_entity_id = oci_core_internet_gateway.terminal.id
+    destination       = "0.0.0.0/0"
+    destination_type  = "CIDR_BLOCK"
+  }
+}
+
+resource "oci_core_security_list" "terminal" {
+  compartment_id = var.compartment_ocid
+  vcn_id         = oci_core_vcn.terminal.id
+  display_name   = "${var.name_prefix}-sec"
+
+  egress_security_rules {
+    destination      = "0.0.0.0/0"
+    destination_type = "CIDR_BLOCK"
+    protocol         = "all"
+  }
+
+  ingress_security_rules {
+    protocol = "6"
+    source   = var.ssh_ingress_cidr
+
+    tcp_options {
+      min = 22
+      max = 22
+    }
+  }
+
+  ingress_security_rules {
+    protocol = "6"
+    source   = "0.0.0.0/0"
+
+    tcp_options {
+      min = 80
+      max = 80
+    }
+  }
+
+  ingress_security_rules {
+    protocol = "6"
+    source   = "0.0.0.0/0"
+
+    tcp_options {
+      min = 443
+      max = 443
+    }
+  }
+}
+
+resource "oci_core_subnet" "terminal" {
+  compartment_id             = var.compartment_ocid
+  vcn_id                     = oci_core_vcn.terminal.id
+  cidr_block                 = var.subnet_cidr
+  display_name               = "${var.name_prefix}-subnet"
+  dns_label                  = "termsubnet"
+  prohibit_public_ip_on_vnic = false
+  route_table_id             = oci_core_route_table.terminal.id
+  security_list_ids          = [oci_core_security_list.terminal.id]
+}
+
+locals {
+  cloud_init = templatefile("${path.module}/cloud-init.tftpl", {
+    repo_url         = var.repo_url
+    repo_branch      = var.repo_branch
+    app_domain       = var.app_domain
+    allowed_origins  = join(",", var.allowed_origins)
+    caddy_http_port  = var.caddy_http_port
+    caddy_https_port = var.caddy_https_port
+    project_dir      = var.project_dir
+  })
+}
+
+resource "oci_core_instance" "terminal" {
+  availability_domain = data.oci_identity_availability_domains.ads.availability_domains[0].name
+  compartment_id      = var.compartment_ocid
+  display_name        = "${var.name_prefix}-instance"
+  shape               = var.instance_shape
+
+  shape_config {
+    ocpus         = var.instance_ocpus
+    memory_in_gbs = var.instance_memory_gbs
+  }
+
+  create_vnic_details {
+    assign_public_ip = true
+    subnet_id        = oci_core_subnet.terminal.id
+    display_name     = "${var.name_prefix}-vnic"
+    hostname_label   = "terminal"
+  }
+
+  metadata = {
+    ssh_authorized_keys = file(var.ssh_public_key_path)
+    user_data           = base64encode(local.cloud_init)
+  }
+
+  source_details {
+    source_type = "image"
+    source_id   = var.image_ocid
+  }
+}

--- a/terminal/infra/oracle-free-tier/outputs.tf
+++ b/terminal/infra/oracle-free-tier/outputs.tf
@@ -1,0 +1,14 @@
+output "instance_public_ip" {
+  description = "Public IP for the terminal instance."
+  value       = oci_core_instance.terminal.public_ip
+}
+
+output "terminal_health_url" {
+  description = "Health endpoint for the deployed terminal backend."
+  value       = "https://${var.app_domain}/health"
+}
+
+output "dns_a_record_hint" {
+  description = "Point this hostname at the instance public IP before expecting TLS issuance."
+  value       = "${var.app_domain} -> ${oci_core_instance.terminal.public_ip}"
+}

--- a/terminal/infra/oracle-free-tier/terraform.tfvars.example
+++ b/terminal/infra/oracle-free-tier/terraform.tfvars.example
@@ -1,0 +1,13 @@
+tenancy_ocid     = "ocid1.tenancy.oc1..example"
+compartment_ocid = "ocid1.compartment.oc1..example"
+user_ocid        = "ocid1.user.oc1..example"
+fingerprint      = "aa:bb:cc:dd:ee:ff"
+private_key_path = "~/.oci/oci_api_key.pem"
+region           = "us-chicago-1"
+image_ocid       = "ocid1.image.oc1.us-chicago-1.example"
+ssh_public_key_path = "~/.ssh/id_ed25519.pub"
+
+app_domain = "terminal.example.com"
+allowed_origins = [
+  "https://cyber-minds.github.io",
+]

--- a/terminal/infra/oracle-free-tier/variables.tf
+++ b/terminal/infra/oracle-free-tier/variables.tf
@@ -1,0 +1,122 @@
+variable "tenancy_ocid" {
+  description = "OCI tenancy OCID."
+  type        = string
+}
+
+variable "compartment_ocid" {
+  description = "OCI compartment OCID for the terminal instance."
+  type        = string
+}
+
+variable "user_ocid" {
+  description = "OCI user OCID used by Terraform."
+  type        = string
+}
+
+variable "fingerprint" {
+  description = "API key fingerprint for the OCI user."
+  type        = string
+}
+
+variable "private_key_path" {
+  description = "Path to the OCI API private key."
+  type        = string
+}
+
+variable "region" {
+  description = "OCI region, for example us-chicago-1."
+  type        = string
+}
+
+variable "image_ocid" {
+  description = "Ubuntu image OCID for the selected region."
+  type        = string
+}
+
+variable "ssh_public_key_path" {
+  description = "Path to the SSH public key to install on the instance."
+  type        = string
+}
+
+variable "name_prefix" {
+  description = "Prefix for OCI resource names."
+  type        = string
+  default     = "cyberminds-terminal"
+}
+
+variable "vcn_cidr" {
+  description = "VCN CIDR block."
+  type        = string
+  default     = "10.40.0.0/16"
+}
+
+variable "subnet_cidr" {
+  description = "Public subnet CIDR block."
+  type        = string
+  default     = "10.40.1.0/24"
+}
+
+variable "ssh_ingress_cidr" {
+  description = "CIDR allowed to SSH to the instance."
+  type        = string
+  default     = "0.0.0.0/0"
+}
+
+variable "instance_shape" {
+  description = "OCI compute shape."
+  type        = string
+  default     = "VM.Standard.A1.Flex"
+}
+
+variable "instance_ocpus" {
+  description = "Number of OCPUs for the free tier ARM instance."
+  type        = number
+  default     = 2
+}
+
+variable "instance_memory_gbs" {
+  description = "Memory allocation in GB for the free tier ARM instance."
+  type        = number
+  default     = 12
+}
+
+variable "repo_url" {
+  description = "Git repository URL to deploy on the instance."
+  type        = string
+  default     = "https://github.com/Cyber-Minds/cyber-minds.github.io.git"
+}
+
+variable "repo_branch" {
+  description = "Git branch to deploy."
+  type        = string
+  default     = "main"
+}
+
+variable "project_dir" {
+  description = "Directory on the VM where the repository should be cloned."
+  type        = string
+  default     = "/opt/cyberminds"
+}
+
+variable "app_domain" {
+  description = "Public DNS name for the terminal backend."
+  type        = string
+}
+
+variable "allowed_origins" {
+  description = "Allowed browser origins for the terminal backend CORS policy."
+  type        = list(string)
+  default     = ["https://cyber-minds.github.io"]
+}
+
+variable "caddy_http_port" {
+  description = "Host HTTP port exposed by the compose stack."
+  type        = number
+  default     = 80
+}
+
+variable "caddy_https_port" {
+  description = "Host HTTPS port exposed by the compose stack."
+  type        = number
+  default     = 443
+}

--- a/tests/smoke.spec.js
+++ b/tests/smoke.spec.js
@@ -189,6 +189,21 @@ test.describe('Navigation', () => {
 // ─── Learner progress ───────────────────────────────────────────────────────
 
 test.describe('Learner progress dashboard', () => {
+  test('visiting a course page records last visited lesson', async ({ page }) => {
+    await page.goto(
+      '/HTML/Courses and Activities/Course 3/SocialEngineeringcourse3.html'
+    );
+    await page.goto('/HTML/course_Contents.html');
+
+    await expect(page.locator('#continueLearningLastVisited')).toContainText(
+      'Course 3 - Social Engineering'
+    );
+    await expect(page.locator('#continueLearningLink')).toHaveAttribute(
+      'href',
+      /SocialEngineeringcourse3\.html/
+    );
+  });
+
   test('course catalog shows local progress, recommendation, and reset flow', async ({
     page,
   }) => {
@@ -390,6 +405,25 @@ test.describe('Shared quiz engine', () => {
     await page.getByRole('button', { name: /retry quiz/i }).click();
     await expect(page.locator('#result')).toHaveText('');
     await expect(page.locator('#retryQuizBtn')).toBeHidden();
+  });
+});
+
+test.describe('Legacy quiz progress', () => {
+  test('legacy quiz submission updates local progress dashboard', async ({
+    page,
+  }) => {
+    await page.goto(
+      '/HTML/Courses and Activities/Course 6/QuizLinuxcourse6.html'
+    );
+
+    await page.locator('label[for="q1-VS"]').first().click();
+    await page.locator('label[for="q2-ignore"]').first().click();
+    await page.locator('label[for="q4-phishing"]').first().click();
+    await page.getByRole('button', { name: /submit quiz/i }).click();
+    await expect(page.locator('#result')).toContainText('/4');
+
+    await page.goto('/HTML/course_Contents.html');
+    await expect(page.locator('#continueLearningQuizCount')).toContainText('1');
   });
 });
 


### PR DESCRIPTION
Fixes learner progress tracking on real course pages and legacy quizzes, and adds an OCI Oracle free tier deployment path for the terminal backend.

## What changed
- decodes real course-page paths before deriving learner progress metadata
- tracks legacy quiz completions by observing existing `#result` score output, not just shared-engine quizzes
- keeps shared-engine quizzes aligned by stamping the canonical quiz id on the page body
- adds Playwright coverage for course-page visit tracking and legacy quiz completion tracking
- adds `terminal/infra/oracle-free-tier/` Terraform and cloud-init files to provision an OCI VM, install Docker, clone the repo, write `terminal/.env`, and launch the production terminal compose stack with Caddy-managed TLS

## Why the terminal is still broken today
The current live terminal backend at `https://terminal.egeuysal.com` is failing in browsers with `ERR_CERT_AUTHORITY_INVALID` during `POST /api/session`. That is an external backend/TLS problem, not a GitHub Pages frontend bug. The Terraform files in this PR are intended to make redeploying that backend onto a clean Oracle free tier VPS straightforward.

## Testing
- `npm run lint:frontend`
- `npm run test:smoke`

## Review focus
- progress metadata derivation from encoded course paths
- legacy quiz completion tracking via existing inline score output
- OCI bootstrap assumptions in `terminal/infra/oracle-free-tier/`
