### PR TITLE
fix(terminal): preserve drafts and harden azure deploy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,7 @@ node_modules/
 .env
 playwright-report/
 test-results/
+**/.terraform/
+*.tfstate
+*.tfstate.*
+*.tfvars

--- a/CSS/mission.css
+++ b/CSS/mission.css
@@ -1,299 +1,135 @@
-/* this page links to index */
+:root {
+  --page-bg: #040b14;
+  --panel-bg: linear-gradient(180deg, rgba(16, 33, 52, 0.95), rgba(10, 22, 36, 0.98));
+  --panel-border: rgba(83, 151, 220, 0.26);
+  --text-main: #f5fbff;
+  --text-muted: #bfd4e6;
+  --accent: #5eb7ff;
+  --shadow: 0 22px 60px rgba(0, 0, 0, 0.32);
+}
+
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
 body {
-  overflow-x: hidden;
+  margin: 0;
+  min-height: 100vh;
+  font-family: 'Space Grotesk', sans-serif;
+  color: var(--text-main);
+  background:
+    radial-gradient(circle at top, rgba(33, 85, 133, 0.3), transparent 34%),
+    linear-gradient(180deg, #02070d 0%, var(--page-bg) 44%, #03070d 100%);
 }
 
 .Parent-container {
-  display: flex;
-  position: relative;
-  flex-direction: column;
-  width: auto;
-  padding-bottom: 2em;
+  min-height: 100vh;
 }
 
-body {
-  font-family: 'Georgia', sans-serif;
-  margin: 0;
-  padding: 0;
-  overflow-x: hidden;
+.mission-main {
+  width: min(1120px, calc(100% - 2rem));
+  margin: 0 auto;
+  padding: 2rem 0 4rem;
+}
+
+.hero {
+  padding: 1rem 0 2rem;
   text-align: center;
-  background-color: #050d18;
-  animation: rotateBoxShadow 4s infinite linear;
 }
 
-@keyframes rotateBoxShadow {
-  0%   { box-shadow: inset 0px 0em 15em #050d18; }
-  33%  { box-shadow: inset 0px 1em 20em #081526; }
-  66%  { box-shadow: inset 0px 0.5em 20em #060f1e; }
-  100% { box-shadow: inset 0em 0em 15em #050c1a; }
-}
-
-header {
-  background-color: #000000;
-  color: #ffffff;
-  text-align: center;
-  padding-left: 1em;
-  padding-bottom: 0.2em;
-  padding-right: 1em;
-  padding-top: 1em;
-  margin-bottom: 20px;
-}
-
-.header-content {
-  display: flex;
-  align-items: center; /* Center the items vertically */
-  justify-content: space-between; /* Space between the logo and nav */
-}
-
-.header-content img {
-  max-height: 3em;
-  margin-right: 3em;
-}
-
-.header-buttons {
-  display: flex;
-  justify-content: space-between;
-  background-color: #000000;
-  padding: 0.5em;
-  padding-left: 6em;
-  padding-right: 6em;
-  align-items: center;
-  flex-grow: 1;
-}
-
-.header-buttons a {
-  text-decoration: none;
-  font-size: 14pt;
-  color: #ffffff;
-  padding: 0.5em 1em;
-  transition: background-color 0.3s;
-  background-color: #174867;
-  text-decoration: none;
-  margin-right: 0.9em;
-  padding: 0.4em 0.8em; /* Smaller padding for a more compact button */
-  border-radius: 0.8em; /* Make the buttons more rounded */
-  white-space: nowrap; /* Prevent text from wrapping */
-}
-
-.header-buttons a:hover {
-  background-color: #286aa7;
-}
-
-main {
-  padding-bottom: 3.5rem;
+.eyebrow {
+  margin: 0 0 0.75rem;
+  letter-spacing: 0.22em;
+  text-transform: uppercase;
+  color: var(--accent);
+  font-size: 0.82rem;
 }
 
 .page-title {
   margin: 0;
-  font-family: 'Space Grotesk', sans-serif;
-  font-size: 4em;
-  font-weight: 700;
-  font-style: normal;
-  word-spacing: 0.2em;
-  letter-spacing: 0.1em;
-  color: transparent; /* Set initial text color to transparent */
-  background: linear-gradient(
-    to left,
-    rgba(0, 0, 0, 0.5),
-    rgba(0, 0, 0, 0),
-    rgba(255, 255, 255, 0.8)
-  ); /* Adjust the colors and stops as needed */
-  background-clip: text;
-  -webkit-background-clip: text;
-  animation: fadeIn 3s forwards; /* Set the duration of the animation */
+  font-size: clamp(2.5rem, 5vw, 4.5rem);
+  line-height: 1;
+  letter-spacing: -0.04em;
 }
 
-@keyframes fadeIn {
-  to {
-    color: rgb(255, 255, 255);
-    background-size: 200% 100%; /* Adjust the size of the gradient */
-  }
+.hero-copy {
+  width: min(720px, 100%);
+  margin: 1.25rem auto 0;
+  color: var(--text-muted);
+  font-size: clamp(1rem, 1.8vw, 1.2rem);
+  line-height: 1.75;
 }
 
-p {
-  color: white;
-  padding-left: 2em;
-  padding-right: 2em;
-  font-family: 'Space Grotesk', sans-serif;
-  line-height: 1.7em;
-  font-size: 2.2em;
+.mission-grid {
+  display: grid;
+  gap: 1.5rem;
 }
 
-ul {
-  padding-left: 1em;
-  color: white;
-  text-align: center;
-  list-style: none;
-  font-family: 'Space Grotesk', sans-serif;
-}
- 
-li {
-  margin-bottom: 0.3em;
-  color: white;
-  font-family: 'Space Grotesk', sans-serif;
-  line-height: 1.5em;
+.mission-card {
+  display: grid;
+  grid-template-columns: minmax(0, 280px) minmax(0, 1fr);
+  align-items: center;
+  gap: 1.5rem;
+  padding: 1.5rem;
+  border: 1px solid var(--panel-border);
+  border-radius: 24px;
+  background: var(--panel-bg);
+  box-shadow: var(--shadow);
 }
 
-a {
-  color: #ffffff;
-  text-decoration: none;
-  font-family: 'Space Grotesk', sans-serif;
-}
-
-h2 {
-  font-size: 1.2em;
-  margin-top: 1.9em;
-  margin-bottom: 0.95em;
-  color: white;
-  /*border-bottom: 2px solid #333;*/
-  padding-bottom: 5px;
-  text-align: center;
-  font-family: 'Space Grotesk', sans-serif;
-}
-
-h3 {
-  font-size: 2.6em;
-  color: white;
-  /*border-bottom: 2px solid #333;*/
-  padding-bottom: 0em;
-  text-align: center;
-  font-family: 'Space Grotesk', sans-serif;
-}
-
-.card-heading {
-  font-size: 1.8em;
-  color: white;
-  padding-bottom: 0.25em;
-  text-align: center;
-  font-family: 'Space Grotesk', sans-serif;
-}
- 
-.card-text {
-  font-size: 1em;
-  color: white;
-  padding-left: 1.5em;
-  padding-right: 1.5em;
-  font-family: 'Space Grotesk', sans-serif;
-  line-height: 1.7em;
-}
- 
-li.card-text {
-  font-size: 2em;
-  line-height: 1.6em;
-  margin-bottom: 0.5em;
-  padding-left: 0;
-  padding-right: 0;
-}
-
-footer {
-  background-color: #0a0a0a;
-  color: #fff;
-  text-align: center;
-  padding: 1em 0;
-  font-size: 0.9em;
-}
-
-.page-footer {
-  background-color: #0a0a0a;
-  color: #fff;
-  text-align: center;
-  padding: 1em 0;
-  font-size: 0.9em;
-  font-family: 'Space Grotesk', sans-serif;
-}
-
-.flex1 {
- border-radius: 0.6em;
-  display: flex;
-  flex-direction: row;
-  background-color: #0d1b2a;
-  border: 1px solid #1a2f4a;
-  margin-bottom: 2.5em;
-  margin-top: 2.5em;
-  margin-left: 12em;
-  margin-right: 12em;
-  height: 30em;
-}
-
-.flex2 {
- border-radius: 0.6em;
-  display: flex;
-  flex-direction: row;
-  background-color: #0d1b2a;
-  border: 1px solid #1a2f4a;
-  margin-bottom: 2.5em;
-  margin-top: 2.5em;
-  margin-left: 12em;
-  margin-right: 12em;
-  height: 30em;
-}
-
-.flex3 {
- border-radius: 0.6em;
-  display: flex;
-  flex-direction: row;
-  background-color: #0d1b2a;
-  border: 1px solid #1a2f4a;
-  margin-bottom: 2.5em;
-  margin-top: 2.5em;
-  margin-left: 12em;
-  margin-right: 12em;
-  height: 30em;
+.media-right {
+  grid-template-columns: minmax(0, 1fr) minmax(0, 280px);
 }
 
 .theIMAGE img {
-  margin-top: 3em;
-  align-self: center;
-  height: 24em;
-  width: auto;
-  flex: 5;
-  margin-left: 1em;
-  margin-right: 1em;
-  margin-bottom: 2em;
-  border-radius: 0.3em 0.3em 0.3em 0.3em;
-  animation: rotateBoxShadow1 4s infinite linear;
+  display: block;
+  width: 100%;
+  height: auto;
+  border-radius: 18px;
+  border: 1px solid rgba(126, 187, 255, 0.24);
 }
 
-@keyframes rotateBoxShadow1 {
-  0% {
-    box-shadow: 0.05em 0.05em 0.9em rgba(24, 55, 68, 0.974);
-  }
-  33% {
-    box-shadow: 0.05em 0.1em 1.3em #4f7ab2;
-  }
-  66% {
-    box-shadow: 0.05em 0.15em 1.5em #38557d;
-  }
-  100% {
-    box-shadow: 0.05em 0.1em 0.95em rgba(17, 48, 70, 0.8);
-  }
+.flexwording h2 {
+  margin: 0 0 0.85rem;
+  font-size: clamp(1.6rem, 2.6vw, 2.3rem);
 }
 
-.flexwording {
-  background: linear-gradient(to bottom, #0000009f, #17263b);
-  flex: 6;
-  border-width: 0.6em;
-  border-style: solid; /* Add this line */
-  border-color: #111a23;
-  margin-top: 3em;
-  margin-bottom: 2.5em;
-  margin-left: 3.6em;
-  margin-right: 3.6em;
-  border-radius: 0.3em 0.3em 0.3em 0.3em;
-  animation: rotateBoxShadow1 4s infinite linear;
+.flexwording p,
+.values-list {
+  margin: 0;
+  color: var(--text-muted);
+  font-size: 1.05rem;
+  line-height: 1.8;
 }
 
-@keyframes rotateBoxShadow1 {
-  0% {
-    box-shadow: 0.05em 0.05em 0.9em rgba(24, 55, 68, 0.974);
+.values-list {
+  padding-left: 1.25rem;
+}
+
+.values-list li + li {
+  margin-top: 0.85rem;
+}
+
+#footer {
+  padding: 1.25rem 1rem 2rem;
+  text-align: center;
+  color: var(--text-muted);
+}
+
+@media (max-width: 840px) {
+  .mission-main {
+    width: min(100% - 1rem, 1120px);
+    padding-top: 1rem;
   }
-  33% {
-    box-shadow: 0.05em 0.1em 1.3em #4f7ab2ac;
+
+  .mission-card,
+  .media-right {
+    grid-template-columns: 1fr;
   }
-  66% {
-    box-shadow: 0.05em 0.15em 1.5em #395e93d3;
-  }
-  100% {
-    box-shadow: 0.05em 0.1em 0.95em rgba(17, 48, 70, 0.8);
+
+  .theIMAGE {
+    order: -1;
   }
 }

--- a/CSS/moreinfo.css
+++ b/CSS/moreinfo.css
@@ -1,197 +1,125 @@
-/* this page links to index */
+:root {
+  --page-bg: #040b14;
+  --panel-bg: linear-gradient(180deg, rgba(16, 33, 52, 0.95), rgba(10, 22, 36, 0.98));
+  --panel-border: rgba(83, 151, 220, 0.24);
+  --text-main: #f5fbff;
+  --text-muted: #c2d5e8;
+  --accent: #5eb7ff;
+  --shadow: 0 22px 60px rgba(0, 0, 0, 0.32);
+}
+
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
 body {
-  overflow-x: hidden;
-  background-color: #050d18;
+  margin: 0;
+  min-height: 100vh;
+  font-family: 'Space Grotesk', sans-serif;
+  color: var(--text-main);
+  background:
+    radial-gradient(circle at top, rgba(33, 85, 133, 0.3), transparent 34%),
+    linear-gradient(180deg, #02070d 0%, var(--page-bg) 44%, #03070d 100%);
 }
 
 .Parent-container {
-  display: flex;
-  position: relative;
-  flex-direction: column;
   min-height: 100vh;
-  width: auto;
-  padding-bottom: 0;
 }
 
-body {
-  font-family: 'Georgia', sans-serif;
-  margin: 0;
-  padding: 0;
-  overflow-x: hidden;
+.main {
+  width: min(1120px, calc(100% - 2rem));
+  margin: 0 auto;
+  padding: 2rem 0 4rem;
+}
+
+.hero {
+  padding: 1rem 0 2rem;
   text-align: center;
-  background-color: black;
-  animation: rotateBoxShadow 4s infinite linear;
 }
 
-@keyframes rotateBoxShadow {
-  0%   { box-shadow: inset 0px 0em 15em #050d18; }
-  33%  { box-shadow: inset 0px 1em 20em #081526; }
-  66%  { box-shadow: inset 0px 0.5em 20em #060f1e; }
-  100% { box-shadow: inset 0em 0em 15em #050c1a; }
-}
-
-header {
-  background-color: #000000;
-  color: #ffffff;
-  text-align: center;
-  padding-left: 1em;
-  padding-bottom: 0.2em;
-  padding-right: 1em;
-  padding-top: 1em;
-  margin-bottom: 20px;
-}
-
-.header-content {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-}
-
-.header-content img {
-  max-height: 3em;
-  margin-right: 3em;
-}
-
-.header-buttons {
-  display: flex;
-  justify-content: space-between;
-  background-color: #000000;
-  padding: 0.5em;
-  padding-left: 6em;
-  padding-right: 6em;
-  align-items: center;
-  flex-grow: 1;
-}
-
-.header-buttons a {
-  text-decoration: none;
-  font-size: 14pt;
-  color: #ffffff;
-  transition: background-color 0.3s;
-  background-color: #174867;
-  margin-right: 0.9em;
-  padding: 0.4em 0.8em;
-  border-radius: 0.8em;
-  white-space: nowrap;
-}
-
-.header-buttons a:hover {
-  background-color: #286aa7;
+.eyebrow {
+  margin: 0 0 0.75rem;
+  letter-spacing: 0.22em;
+  text-transform: uppercase;
+  color: var(--accent);
+  font-size: 0.82rem;
 }
 
 .page-title {
-  font-family: 'Space Grotesk', sans-serif;
-  font-size: 4em;
-  font-weight: 700;
-  word-spacing: 0.2em;
-  letter-spacing: 0.1em;
-  color: transparent;
-  background: linear-gradient(
-    to left,
-    rgba(0, 0, 0, 0.5),
-    rgba(0, 0, 0, 0),
-    rgba(255, 255, 255, 0.8)
-  );
-  background-clip: text;
-  -webkit-background-clip: text;
-  animation: fadeIn 3s forwards;
+  margin: 0;
+  font-size: clamp(2.5rem, 5vw, 4.5rem);
+  line-height: 1;
+  letter-spacing: -0.04em;
 }
 
-@keyframes fadeIn {
-  to {
-    color: rgb(255, 255, 255);
-    background-size: 200% 100%;
-  }
+.hero-copy {
+  width: min(720px, 100%);
+  margin: 1.25rem auto 0;
+  color: var(--text-muted);
+  font-size: clamp(1rem, 1.8vw, 1.2rem);
+  line-height: 1.75;
 }
 
-p {
-  line-height: 1.6;
-  color: white;
-  padding-left: 20px;
-  padding-right: 20px;
-  font-family: 'Space Grotesk', sans-serif;
+.text-container {
+  padding: 1.5rem;
+  border: 1px solid var(--panel-border);
+  border-radius: 24px;
+  background: var(--panel-bg);
+  box-shadow: var(--shadow);
 }
 
-ul {
-  padding-left: 20px;
-  color: white;
-  text-align: center;
-  list-style: none;
+.text-container h2 {
+  margin: 0 0 0.85rem;
+  font-size: clamp(1.4rem, 2vw, 1.9rem);
 }
 
-li {
-  margin-bottom: 5px;
-  color: white;
-  font-family: 'Space Grotesk', sans-serif;
+.text-container p,
+.text-container li {
+  color: var(--text-muted);
+  font-size: 1rem;
+  line-height: 1.8;
 }
 
-a {
-  color: #ffffff;
-  text-decoration: none;
-  font-family: 'Space Grotesk', sans-serif;
-}
-
-h2 {
-  font-size: 24px;
-  margin-top: 30px;
-  margin-bottom: 15px;
-  color: white;
-  padding-bottom: 5px;
-  text-align: center;
-  font-family: 'Space Grotesk', sans-serif;
-}
-
-footer {
-  background-color: #0a0a0a;
-  color: #fff;
-  text-align: center;
-  padding: 1em 0;
-  font-size: 0.9em;
-  margin-top: auto;
-}
-
-.emailForCyberminds {
-  color: #ffffff;
-  text-decoration: none;
-  font-size: 1em;
-}
-
-.emailForCyberminds:hover {
-  color: #ffffff;
-  text-decoration: underline;
-  font-weight: bold;
-}
-
-/* ── LAYOUT ── */
-.main {
-  display: flex;
-  flex-direction: column;
-  gap: 1.5em;
-  padding: 1em 4em 1.5em;
+.text-container ul {
+  margin: 1rem 0 0;
+  padding-left: 1.25rem;
+  text-align: left;
 }
 
 .bottom-grid {
   display: grid;
-  grid-template-columns: 1fr 1fr;
-  gap: 1.5em;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 1.5rem;
+  margin-top: 1.5rem;
 }
 
+.full-width,
 .bottom-span {
   grid-column: 1 / -1;
 }
 
-.text-container {
-  background: linear-gradient(to bottom, #0d1b2a, #111f30);
-  border-radius: 1em;
-  padding: 1.5em;
-  margin: 0;
-  border: 1px solid #1a2f4a;
-  animation: rotateBoxShadow1 4s infinite linear;
+.text-container a {
+  color: var(--text-main);
+  text-decoration: underline;
+  text-decoration-color: rgba(94, 183, 255, 0.65);
+  text-underline-offset: 0.2em;
 }
 
-@keyframes rotateBoxShadow1 {
-  0%, 100% { box-shadow: 0 0 14px rgba(20, 50, 90, 0.7); }
-  25%       { box-shadow: 0 0 22px rgba(25, 65, 120, 0.6); }
-  50%, 75%  { box-shadow: 0 0 8px rgba(15, 40, 75, 0.4); }
+#footer {
+  padding: 1.25rem 1rem 2rem;
+  text-align: center;
+  color: var(--text-muted);
 }
 
+@media (max-width: 840px) {
+  .main {
+    width: min(100% - 1rem, 1120px);
+    padding-top: 1rem;
+  }
+
+  .bottom-grid {
+    grid-template-columns: 1fr;
+  }
+}

--- a/HTML/mission.html
+++ b/HTML/mission.html
@@ -18,61 +18,87 @@
   <body>
     <div class="Parent-container">
       <header id="site-header"></header>
-
-      <p class="page-title">Our Mission</p>
-
-      <div class="flex1">
-        <div class="theIMAGE">
-          <img
-            src="../Images/mission-image.jpg"
-            alt="Mission Image"
-          />
-        </div>
-        <div class="flexwording">
-          <h3>Mission</h3>
-          <p>
-            Our mission is to provide free engaging cybersecurity education,
-            interactive activities, and useful resources, equipping users with
-            the tools to protect themselves online and contribute to a secure
-            digital landscape in the future.
+      <main class="mission-main">
+        <section class="hero">
+          <p class="eyebrow">CyberMinds</p>
+          <h1 class="page-title">Our Mission</h1>
+          <p class="hero-copy">
+            We build free, practical cybersecurity learning experiences that
+            help students and beginners understand threats, practice defensive
+            skills, and grow confidence online.
           </p>
-        </div>
-      </div>
+        </section>
 
-      <div class="flex2">
-        <div class="flexwording">
-          <h3>Vision</h3>
-          <p>
-            As a team, we wish to empower individuals with cybersecurity
-            knowledge and skills to navigate the digital landscape securely,
-            creating a future world where everyone can confidently use the
-            benefits of technology without compromising their online safety.
-          </p>
-        </div>
-        <div class="theIMAGE">
-          <img
-            src="../Images/vission-img.jpg"
-            alt="Vision Image"
-          />
-        </div>
-      </div>
-      <div class="flex3">
-        <div class="theIMAGE">
-          <img src="../Images/values-img.jpg"  alt="Values Image" />
-        </div>
-        <div class="flexwording">
-          <h3>Values</h3>
-          <ul>
-            <li class="card-text">1. Education: We strive to make cybersecurity knowledge accessible to all.</li>
-            <li class="card-text">2. Empowerment: We wish to empower individuals to take control of their digital world.</li>
-            <li class="card-text">3. Diversity: We are committed to creating an inclusive and diverse community, ensuring that cybersecurity education is accessible to individuals from all backgrounds.</li>
-          </ul>
-        </div>
-      </div>
+        <section class="mission-grid" aria-label="CyberMinds mission details">
+          <article class="mission-card media-left">
+            <div class="theIMAGE">
+              <img
+                src="../Images/mission-image.jpg"
+                alt="Students collaborating on cybersecurity education"
+                loading="lazy"
+              />
+            </div>
+            <div class="flexwording">
+              <h2>Mission</h2>
+              <p>
+                Our mission is to provide accessible cybersecurity education,
+                interactive activities, and useful resources so learners can
+                protect themselves online and contribute to a safer digital
+                world.
+              </p>
+            </div>
+          </article>
+
+          <article class="mission-card media-right">
+            <div class="flexwording">
+              <h2>Vision</h2>
+              <p>
+                We want more people to navigate the digital landscape securely,
+                use technology with confidence, and build habits that reduce
+                risk without shutting them out of modern tools.
+              </p>
+            </div>
+            <div class="theIMAGE">
+              <img
+                src="../Images/vission-img.jpg"
+                alt="A digital globe surrounded by connected security systems"
+                loading="lazy"
+              />
+            </div>
+          </article>
+
+          <article class="mission-card media-left">
+            <div class="theIMAGE">
+              <img
+                src="../Images/values-img.jpg"
+                alt="Cybersecurity learning represented by a shield and open book"
+                loading="lazy"
+              />
+            </div>
+            <div class="flexwording">
+              <h2>Values</h2>
+              <ul class="values-list">
+                <li>
+                  <strong>Education.</strong> We make cybersecurity concepts
+                  understandable and useful.
+                </li>
+                <li>
+                  <strong>Empowerment.</strong> We give learners tools they can
+                  apply on their own devices and accounts.
+                </li>
+                <li>
+                  <strong>Inclusion.</strong> We design content for students
+                  from different backgrounds, skill levels, and learning styles.
+                </li>
+              </ul>
+            </div>
+          </article>
+        </section>
+      </main>
     </div>
 
     <footer id="footer">
-      <p>&copy; 2025 CyberMinds, Inc. All rights reserved.</p>
+      <p>&copy; 2026 CyberMinds, Inc. All rights reserved.</p>
     </footer>
 
     <script src="../Javascript/header.js"></script>
@@ -80,4 +106,3 @@
     <script src="../Javascript/analytics.js"></script>
   </body>
 </html>
-

--- a/HTML/moreinfo.html
+++ b/HTML/moreinfo.html
@@ -18,9 +18,15 @@
   <body>
     <div class="Parent-container">
       <header id="site-header"></header>
-      <div class="page-title">More Info</div>
-
       <main class="main">
+        <section class="hero">
+          <p class="eyebrow">CyberMinds</p>
+          <h1 class="page-title">More Info</h1>
+          <p class="hero-copy">
+            Learn what the site offers, what data it does and does not store,
+            and how to contact the team when you need help.
+          </p>
+        </section>
 
         <div class="text-container full-width">
           <h2>About the Website</h2>
@@ -36,15 +42,15 @@
           <div class="text-container">
             <h2>Security and Privacy</h2>
             <p>
-              We prioritize the security and privacy of our users. Here are some
-              measures we take to ensure your data is safe:
+              We prioritize safe defaults and low-friction access. Here are the
+              most important privacy details for this site:
             </p>
             <ul>
-              <li>Our website does not secure your personal information.</li>
-              <li>Regular security checks are conducted often to identify and address potential vulnerabilities.</li>
-              <li>Github's security features are used to safeguard our code repositories and data.</li>
-              <li>Your data is stored on secure servers, and we follow strict privacy policies.</li>
-              <li>We are committed to transparent communication regarding any security incidents or updates.</li>
+              <li>No sign-in is required to browse lessons or track progress.</li>
+              <li>Course, quiz, and CTF progress is stored locally in your browser on this device.</li>
+              <li>We avoid collecting unnecessary personal information for the learning experience.</li>
+              <li>We use GitHub and standard platform protections to manage source code and deployments.</li>
+              <li>We review bugs and deployment issues and communicate changes as the project evolves.</li>
             </ul>
           </div>
 
@@ -70,13 +76,11 @@
             </p>
           </div>
         </div>
-
       </main>
-
-      <footer id="footer">
-        <p>&copy; 2026 CyberMinds, Inc. All rights reserved.</p>
-      </footer>
     </div>
+    <footer id="footer">
+      <p>&copy; 2026 CyberMinds, Inc. All rights reserved.</p>
+    </footer>
 
     <script src="../Javascript/header.js"></script>
     <script src="../Javascript/footer.js"></script>

--- a/Javascript/terminal/app/core.js
+++ b/Javascript/terminal/app/core.js
@@ -414,7 +414,17 @@ function queueDraftSave() {
     return;
   }
   window.clearTimeout(autoSaveTimer);
-  autoSaveTimer = window.setTimeout(persistActiveDraft, 250);
+  autoSaveTimer = null;
+  persistActiveDraft();
+}
+
+function flushDraftSave() {
+  if (!editor) {
+    return;
+  }
+  window.clearTimeout(autoSaveTimer);
+  autoSaveTimer = null;
+  persistActiveDraft();
 }
 
 function setMobileView(view) {

--- a/Javascript/terminal/app/ui.js
+++ b/Javascript/terminal/app/ui.js
@@ -462,7 +462,19 @@ function initEditor() {
       queueDraftSave();
     });
 
-    switchLanguage('python');
+    const flushDraftOnExit = () => {
+      flushDraftSave();
+    };
+
+    window.addEventListener('pagehide', flushDraftOnExit);
+    window.addEventListener('beforeunload', flushDraftOnExit);
+    document.addEventListener('visibilitychange', () => {
+      if (document.visibilityState === 'hidden') {
+        flushDraftSave();
+      }
+    });
+
+    switchLanguage('python', { persistCurrent: false });
     renderFileTabs();
     loadChallenge(activeChallengeId, false);
 

--- a/Javascript/terminal/state.js
+++ b/Javascript/terminal/state.js
@@ -41,7 +41,7 @@ const isLocalHost = ['localhost', '127.0.0.1'].includes(
 );
 const defaultApiOrigin = isLocalHost
   ? window.location.origin
-  : 'https://terminal.egeuysal.com';
+  : 'https://cyberminds-terminal-20260621-ncus.northcentralus.cloudapp.azure.com';
 const configuredApiOrigin = query.get('apiOrigin') || defaultApiOrigin;
 const apiOrigin = (() => {
   try {

--- a/terminal/infra/azure-vm/.terraform.lock.hcl
+++ b/terminal/infra/azure-vm/.terraform.lock.hcl
@@ -1,0 +1,43 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/azurerm" {
+  version     = "4.78.0"
+  constraints = "~> 4.0"
+  hashes = [
+    "h1:6MQ2q38HDc+UElLT8Sak5OqvxagxijWyElv259wTryQ=",
+    "zh:0d304aa909cc991ebde65d69c46f9843b08e88c3e9e0da14135ffa0da6aa2d16",
+    "zh:30e3e8ca8e21d58db6e6136bb04e62cfb2e1c6806598fb472e8d7a1a73911eec",
+    "zh:37b313bb082883568e16afe8f389bcf30e5eba0367b0dce52f5206d17237c8d8",
+    "zh:3fb84cfb9cce89e5abc5b066708a2aa84913bc5fa2c97d2aa89082a84de5fc51",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:b622594b5024b3f7d37705e0fa2ceb7cd9fd6957e2d6f53b17b5dd7f6297cf4e",
+    "zh:c49ac67474cae86f6792db6042739a2a08a8ec38c5fcfd5d9764b5835595614a",
+    "zh:ce4031214a3f7ba267f1ae2d24b1e4e9e394af2afc4ea7833e67116a5042a614",
+    "zh:d0de2877cf64c91a7734cd170a4e1ec91e8822655760317b1a5e03c61cca3241",
+    "zh:e573830323bd1df38a0589e3f23c3f4124e1d8ab7875eeeec63e97fecdf48f4c",
+    "zh:f0c975ba9d6b7420f38e45e38adfe22f1b88ebed003bae35cb2c9223f36c79f5",
+    "zh:f75cc41e621ac23cbc948570672b191d69f9d4056342a8e82f1c59cb9f76b2df",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/tls" {
+  version     = "4.3.0"
+  constraints = "~> 4.0"
+  hashes = [
+    "h1:5bCU/c+2HUh7GhclzNSH6gAuoCS4inW3obEtRAwu6WQ=",
+    "zh:0ab58d6f8991d436c7d2dbd89ed814709b949b07ac5a54ee53b0aec1fa772a8b",
+    "zh:60b347abcb56f45d97c56f14d895069cd15a83993f199777f571b79fea3642ee",
+    "zh:6889be32640349230de3f23856e6f04e0e9ced4a84a27d3f552fa54684448218",
+    "zh:73f8e1ecf7135033165fb14b7e8bf4d656f3ce13065ec35762ea0481975328c7",
+    "zh:94ce25ee253eca0b42cae9c856b36bca8103b6453012d1b279c3623c805f2d42",
+    "zh:96bc6de9fd67bc446fd11257872e1ffb1029a996ed1d65a3f6b43f6d408ad9ab",
+    "zh:97c609a310a51bfd504d704e036d72064a84bf0bdb36cc08cd4cc66098212b41",
+    "zh:a12c16e94533c5bd123f75032576b9dc91dd5d5ccd5f7cf331d0f2e1adc55cf8",
+    "zh:c4f014f876adf7af57188795050bda5b0029d8c7d7773031102b6c36dcf1fc21",
+    "zh:d9b0a21583aaa3df3a95394fb949a3c515ff71c2ff5a1fc4a73d364aa90bfca5",
+    "zh:da510d22f0c6d71ad19a76406f106b782448f512375787ecfabb338ed1e311a7",
+    "zh:f0e9447a9ce3a24cdaa113089e65663c836d8b9bfdb915a1c0284e0112cab5c0",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+  ]
+}

--- a/terminal/infra/azure-vm/README.md
+++ b/terminal/infra/azure-vm/README.md
@@ -1,0 +1,80 @@
+# Azure VM deploy for the CyberMinds terminal
+
+This Terraform stack provisions a small Azure VM, assigns a static public IP
+with an Azure-managed DNS hostname, installs Docker, clones the repo, and
+starts the existing production terminal stack from
+`terminal/docker-compose.prod.yml`.
+
+## What it creates
+
+- resource group wiring compatible with Azure CLI auth
+- virtual network, subnet, public IP, NIC, and network security group
+- one Ubuntu VM
+- cloud-init bootstrapping for Docker, repo clone, `.env`, and systemd
+
+## Why this fixes the current outage
+
+The current public terminal endpoint uses `terminal.egeuysal.com`, which is
+serving an invalid certificate chain to browsers. This stack uses an
+Azure-managed hostname like:
+
+`https://cyberminds-terminal-20260621-ncus.northcentralus.cloudapp.azure.com`
+
+That hostname terminates through the repo's Caddy config and should obtain a
+valid certificate automatically once the VM is up and ports 80/443 are open.
+
+## Prerequisites
+
+- `az login` already completed
+- `terraform` installed
+- a resource group created, for example:
+
+```bash
+az group create --name cyberminds-terminal-ncus-rg --location northcentralus
+```
+
+## Usage
+
+```bash
+cd terminal/infra/azure-vm
+cp terraform.tfvars.example terraform.tfvars
+```
+
+Edit `terraform.tfvars` and set:
+
+- `subscription_id`
+- `admin_ssh_public_key`
+- optionally `domain_name_label` if the default is already taken
+
+Then run:
+
+```bash
+terraform init
+terraform apply
+```
+
+After apply:
+
+```bash
+terraform output public_fqdn
+terraform output terminal_health_url
+```
+
+Verify health:
+
+```bash
+curl -I "$(terraform output -raw terminal_health_url)"
+```
+
+SSH access:
+
+```bash
+terraform output -raw ssh_command
+```
+
+## Notes
+
+- This deploy path uses the Azure hostname directly, so it does not require
+  moving DNS for `terminal.egeuysal.com`.
+- The frontend terminal default API origin should match the `public_fqdn`
+  output if the DNS label changes.

--- a/terminal/infra/azure-vm/README.md
+++ b/terminal/infra/azure-vm/README.md
@@ -45,6 +45,7 @@ Edit `terraform.tfvars` and set:
 - `subscription_id`
 - `admin_ssh_public_key`
 - optionally `domain_name_label` if the default is already taken
+- optionally `ssh_allowed_source_addresses` if you want public SSH access
 
 Then run:
 
@@ -71,6 +72,8 @@ SSH access:
 ```bash
 terraform output -raw ssh_command
 ```
+
+Public SSH is disabled unless you set `ssh_allowed_source_addresses`.
 
 ## Notes
 

--- a/terminal/infra/azure-vm/cloud-init.tftpl
+++ b/terminal/infra/azure-vm/cloud-init.tftpl
@@ -1,0 +1,52 @@
+#cloud-config
+package_update: true
+package_upgrade: true
+packages:
+  - ca-certificates
+  - curl
+  - git
+  - docker.io
+  - docker-compose-v2
+
+write_files:
+  - path: /etc/systemd/system/cyberminds-terminal.service
+    permissions: "0644"
+    content: |
+      [Unit]
+      Description=CyberMinds terminal deployment
+      Requires=docker.service
+      After=docker.service network-online.target
+      Wants=network-online.target
+
+      [Service]
+      Type=oneshot
+      RemainAfterExit=yes
+      WorkingDirectory=${project_dir}/terminal
+      ExecStart=/usr/bin/docker compose -f docker-compose.prod.yml --env-file .env up -d --build
+      ExecStop=/usr/bin/docker compose -f docker-compose.prod.yml --env-file .env down
+      TimeoutStartSec=0
+
+      [Install]
+      WantedBy=multi-user.target
+
+runcmd:
+  - usermod -aG docker ${admin_username}
+  - systemctl enable docker
+  - systemctl start docker
+  - mkdir -p ${project_dir}
+  - |
+    if [ ! -d "${project_dir}/.git" ]; then
+      git clone --branch ${repo_branch} --depth 1 ${repo_url} ${project_dir}
+    else
+      git -C ${project_dir} fetch origin ${repo_branch}
+      git -C ${project_dir} checkout ${repo_branch}
+      git -C ${project_dir} reset --hard origin/${repo_branch}
+    fi
+  - |
+    cat > ${project_dir}/terminal/.env <<'EOF'
+    APP_DOMAIN=${app_domain}
+    ALLOWED_ORIGINS=${allowed_origins}
+    EOF
+  - systemctl daemon-reload
+  - systemctl enable cyberminds-terminal.service
+  - systemctl restart cyberminds-terminal.service

--- a/terminal/infra/azure-vm/main.tf
+++ b/terminal/infra/azure-vm/main.tf
@@ -1,0 +1,146 @@
+terraform {
+  required_version = ">= 1.5.0"
+
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "~> 4.0"
+    }
+    tls = {
+      source  = "hashicorp/tls"
+      version = "~> 4.0"
+    }
+  }
+}
+
+provider "azurerm" {
+  subscription_id                 = var.subscription_id
+  resource_provider_registrations = "none"
+  features {}
+}
+
+locals {
+  project_name = "cyberminds-terminal"
+  fqdn         = azurerm_public_ip.terminal.fqdn
+  custom_data = base64encode(templatefile("${path.module}/cloud-init.tftpl", {
+    admin_username  = var.admin_username
+    project_dir     = var.project_dir
+    repo_url        = var.repo_url
+    repo_branch     = var.repo_branch
+    app_domain      = azurerm_public_ip.terminal.fqdn
+    allowed_origins = join(",", var.allowed_origins)
+  }))
+}
+
+resource "azurerm_virtual_network" "terminal" {
+  name                = "${local.project_name}-vnet"
+  address_space       = ["10.24.0.0/16"]
+  location            = var.location
+  resource_group_name = var.resource_group_name
+}
+
+resource "azurerm_subnet" "terminal" {
+  name                 = "${local.project_name}-subnet"
+  resource_group_name  = var.resource_group_name
+  virtual_network_name = azurerm_virtual_network.terminal.name
+  address_prefixes     = ["10.24.1.0/24"]
+}
+
+resource "azurerm_network_security_group" "terminal" {
+  name                = "${local.project_name}-nsg"
+  location            = var.location
+  resource_group_name = var.resource_group_name
+
+  security_rule {
+    name                       = "allow-ssh"
+    priority                   = 100
+    direction                  = "Inbound"
+    access                     = "Allow"
+    protocol                   = "Tcp"
+    source_port_range          = "*"
+    destination_port_range     = "22"
+    source_address_prefix      = "*"
+    destination_address_prefix = "*"
+  }
+
+  security_rule {
+    name                       = "allow-http"
+    priority                   = 110
+    direction                  = "Inbound"
+    access                     = "Allow"
+    protocol                   = "Tcp"
+    source_port_range          = "*"
+    destination_port_range     = "80"
+    source_address_prefix      = "*"
+    destination_address_prefix = "*"
+  }
+
+  security_rule {
+    name                       = "allow-https"
+    priority                   = 120
+    direction                  = "Inbound"
+    access                     = "Allow"
+    protocol                   = "Tcp"
+    source_port_range          = "*"
+    destination_port_range     = "443"
+    source_address_prefix      = "*"
+    destination_address_prefix = "*"
+  }
+}
+
+resource "azurerm_public_ip" "terminal" {
+  name                = "${local.project_name}-pip"
+  location            = var.location
+  resource_group_name = var.resource_group_name
+  allocation_method   = "Static"
+  sku                 = "Standard"
+  domain_name_label   = var.domain_name_label
+}
+
+resource "azurerm_network_interface" "terminal" {
+  name                = "${local.project_name}-nic"
+  location            = var.location
+  resource_group_name = var.resource_group_name
+
+  ip_configuration {
+    name                          = "primary"
+    subnet_id                     = azurerm_subnet.terminal.id
+    private_ip_address_allocation = "Dynamic"
+    public_ip_address_id          = azurerm_public_ip.terminal.id
+  }
+}
+
+resource "azurerm_network_interface_security_group_association" "terminal" {
+  network_interface_id      = azurerm_network_interface.terminal.id
+  network_security_group_id = azurerm_network_security_group.terminal.id
+}
+
+resource "azurerm_linux_virtual_machine" "terminal" {
+  name                            = local.project_name
+  resource_group_name             = var.resource_group_name
+  location                        = var.location
+  size                            = var.vm_size
+  admin_username                  = var.admin_username
+  disable_password_authentication = true
+  network_interface_ids           = [azurerm_network_interface.terminal.id]
+  custom_data                     = local.custom_data
+
+  admin_ssh_key {
+    username   = var.admin_username
+    public_key = var.admin_ssh_public_key
+  }
+
+  os_disk {
+    caching              = "ReadWrite"
+    storage_account_type = "Standard_LRS"
+  }
+
+  source_image_reference {
+    publisher = "Canonical"
+    offer     = "0001-com-ubuntu-server-jammy"
+    sku       = "22_04-lts-gen2"
+    version   = "latest"
+  }
+
+  computer_name = "cyberminds-terminal"
+}

--- a/terminal/infra/azure-vm/main.tf
+++ b/terminal/infra/azure-vm/main.tf
@@ -51,16 +51,20 @@ resource "azurerm_network_security_group" "terminal" {
   location            = var.location
   resource_group_name = var.resource_group_name
 
-  security_rule {
-    name                       = "allow-ssh"
-    priority                   = 100
-    direction                  = "Inbound"
-    access                     = "Allow"
-    protocol                   = "Tcp"
-    source_port_range          = "*"
-    destination_port_range     = "22"
-    source_address_prefix      = "*"
-    destination_address_prefix = "*"
+  dynamic "security_rule" {
+    for_each = length(var.ssh_allowed_source_addresses) > 0 ? [1] : []
+
+    content {
+      name                       = "allow-ssh"
+      priority                   = 100
+      direction                  = "Inbound"
+      access                     = "Allow"
+      protocol                   = "Tcp"
+      source_port_range          = "*"
+      destination_port_range     = "22"
+      source_address_prefixes    = var.ssh_allowed_source_addresses
+      destination_address_prefix = "*"
+    }
   }
 
   security_rule {

--- a/terminal/infra/azure-vm/outputs.tf
+++ b/terminal/infra/azure-vm/outputs.tf
@@ -1,0 +1,19 @@
+output "public_ip_address" {
+  description = "Static public IP address for the terminal VM."
+  value       = azurerm_public_ip.terminal.ip_address
+}
+
+output "public_fqdn" {
+  description = "Azure-managed public hostname for the terminal VM."
+  value       = azurerm_public_ip.terminal.fqdn
+}
+
+output "terminal_health_url" {
+  description = "Health endpoint for the deployed terminal backend."
+  value       = "https://${azurerm_public_ip.terminal.fqdn}/health"
+}
+
+output "ssh_command" {
+  description = "SSH command for connecting to the VM."
+  value       = "ssh ${var.admin_username}@${azurerm_public_ip.terminal.fqdn}"
+}

--- a/terminal/infra/azure-vm/terraform.tfvars.example
+++ b/terminal/infra/azure-vm/terraform.tfvars.example
@@ -6,6 +6,10 @@ admin_username        = "azureuser"
 admin_ssh_public_key  = "ssh-ed25519 AAAA..."
 domain_name_label     = "cyberminds-terminal-20260621-ncus"
 
+ssh_allowed_source_addresses = [
+  "203.0.113.10/32",
+]
+
 allowed_origins = [
   "https://cyber-minds.github.io",
 ]

--- a/terminal/infra/azure-vm/terraform.tfvars.example
+++ b/terminal/infra/azure-vm/terraform.tfvars.example
@@ -1,0 +1,11 @@
+subscription_id       = "4061ab9f-5409-4b9e-93cf-a2944f954f01"
+resource_group_name   = "cyberminds-terminal-ncus-rg"
+location              = "northcentralus"
+vm_size               = "Standard_B2as_v2"
+admin_username        = "azureuser"
+admin_ssh_public_key  = "ssh-ed25519 AAAA..."
+domain_name_label     = "cyberminds-terminal-20260621-ncus"
+
+allowed_origins = [
+  "https://cyber-minds.github.io",
+]

--- a/terminal/infra/azure-vm/variables.tf
+++ b/terminal/infra/azure-vm/variables.tf
@@ -1,0 +1,65 @@
+variable "subscription_id" {
+  description = "Azure subscription ID."
+  type        = string
+}
+
+variable "resource_group_name" {
+  description = "Existing Azure resource group name."
+  type        = string
+  default     = "cyberminds-terminal-ncus-rg"
+}
+
+variable "location" {
+  description = "Azure region for the VM."
+  type        = string
+  default     = "northcentralus"
+}
+
+variable "vm_size" {
+  description = "Azure VM size for the terminal host."
+  type        = string
+  default     = "Standard_B2as_v2"
+}
+
+variable "admin_username" {
+  description = "Admin username for the Linux VM."
+  type        = string
+  default     = "azureuser"
+}
+
+variable "admin_ssh_public_key" {
+  description = "SSH public key for VM access."
+  type        = string
+}
+
+variable "project_dir" {
+  description = "Directory on the VM where the repo will be cloned."
+  type        = string
+  default     = "/opt/cyberminds"
+}
+
+variable "repo_url" {
+  description = "Git repository URL to deploy from."
+  type        = string
+  default     = "https://github.com/Cyber-Minds/cyber-minds.github.io.git"
+}
+
+variable "repo_branch" {
+  description = "Branch to clone on the VM."
+  type        = string
+  default     = "main"
+}
+
+variable "domain_name_label" {
+  description = "Azure public IP DNS label. Final hostname becomes <label>.<region>.cloudapp.azure.com."
+  type        = string
+  default     = "cyberminds-terminal-20260621-ncus"
+}
+
+variable "allowed_origins" {
+  description = "Allowed browser origins for the terminal backend CORS policy."
+  type        = list(string)
+  default = [
+    "https://cyber-minds.github.io",
+  ]
+}

--- a/terminal/infra/azure-vm/variables.tf
+++ b/terminal/infra/azure-vm/variables.tf
@@ -32,6 +32,12 @@ variable "admin_ssh_public_key" {
   type        = string
 }
 
+variable "ssh_allowed_source_addresses" {
+  description = "Optional CIDR ranges allowed to reach SSH on the VM. Leave empty to disable public SSH."
+  type        = list(string)
+  default     = []
+}
+
 variable "project_dir" {
   description = "Directory on the VM where the repo will be cloned."
   type        = string

--- a/tests/smoke.spec.js
+++ b/tests/smoke.spec.js
@@ -186,6 +186,34 @@ test.describe('Navigation', () => {
   });
 });
 
+test.describe('Content pages', () => {
+  test('mission page exposes a clear h1 and responsive content cards', async ({
+    page,
+  }) => {
+    await page.goto('/HTML/mission.html');
+    await expect(page.getByRole('heading', { level: 1 })).toHaveText(
+      'Our Mission'
+    );
+
+    const overflowing = await page.evaluate(() => {
+      return document.documentElement.scrollWidth > window.innerWidth;
+    });
+    expect(overflowing).toBe(false);
+  });
+
+  test('more info page uses semantic headings and visible contact link', async ({
+    page,
+  }) => {
+    await page.goto('/HTML/moreinfo.html');
+    await expect(page.getByRole('heading', { level: 1 })).toHaveText(
+      'More Info'
+    );
+    await expect(
+      page.getByRole('link', { name: /CYBER-MINDS@outlook\.com/i })
+    ).toBeVisible();
+  });
+});
+
 // ─── Learner progress ───────────────────────────────────────────────────────
 
 test.describe('Learner progress dashboard', () => {
@@ -479,5 +507,26 @@ test.describe('Mock terminal', () => {
     // Toast text persists in the DOM even after the visible class is removed,
     // so toContainText() matches reliably within the retry window.
     await expect(page.locator('#toast')).toContainText(/completed/i);
+  });
+
+  test('completed mock challenge appears in learner progress dashboard', async ({
+    page,
+  }) => {
+    await page.goto(TERMINAL_MOCK_URL);
+    await waitForMockReady(page);
+
+    await page.evaluate(() => {
+      // eslint-disable-next-line no-undef
+      window.setMockFile(
+        'report.txt',
+        'owner: cyberminds, group: staff, perms: 0755\n'
+      );
+    });
+
+    await page.locator('#checkSolutionBtn').click();
+    await expect(page.locator('#progressChip')).toContainText('1/');
+
+    await page.goto('/HTML/course_Contents.html');
+    await expect(page.locator('#continueLearningCtfCount')).toContainText('1');
   });
 });

--- a/tests/smoke.spec.js
+++ b/tests/smoke.spec.js
@@ -74,7 +74,7 @@ window.monaco = {
       const model = { language: options.language || 'plaintext' };
       const listeners = [];
       if (element) element.textContent = value;
-      return {
+      const editor = {
         getValue: () => value,
         setValue(nextValue) {
           value = String(nextValue || '');
@@ -87,6 +87,8 @@ window.monaco = {
           return { dispose() {} };
         },
       };
+      window.__cybermindsMonacoEditor = editor;
+      return editor;
     },
   },
 };
@@ -528,5 +530,53 @@ test.describe('Mock terminal', () => {
 
     await page.goto('/HTML/course_Contents.html');
     await expect(page.locator('#continueLearningCtfCount')).toContainText('1');
+  });
+
+  test('draft autosaves before a fast reload and restores the edit', async ({
+    page,
+  }) => {
+    await page.goto(TERMINAL_MOCK_URL);
+    await waitForMockReady(page);
+    await page.waitForFunction(
+      () => !!window.__cybermindsMonacoEditor,
+      null,
+      { timeout: 10_000 }
+    );
+
+    await page.evaluate(() => {
+      window.__cybermindsMonacoEditor.setValue(
+        '# recovered draft\nprint("keep this after reload")\n'
+      );
+    });
+
+    const savedDraftKeys = await page.evaluate(() =>
+      Object.keys(window.localStorage).filter((key) =>
+        key.startsWith('cm_terminal_draft_v1')
+      )
+    );
+
+    expect(savedDraftKeys).toContain(
+      'cm_terminal_draft_v1:linux-basics:template:python'
+    );
+
+    await page.reload();
+    await waitForMockReady(page);
+    await page.waitForFunction(
+      () => !!window.__cybermindsMonacoEditor,
+      null,
+      { timeout: 10_000 }
+    );
+
+    const restoredDraft = await page.evaluate(() =>
+      window.localStorage.getItem(
+        'cm_terminal_draft_v1:linux-basics:template:python'
+      )
+    );
+
+    expect(restoredDraft).toContain('keep this after reload');
+
+    await expect(page.locator('#editor')).toContainText(
+      'keep this after reload'
+    );
   });
 });


### PR DESCRIPTION
This updates the terminal frontend to point at the Azure backend, fixes draft persistence so fast reloads no longer overwrite saved code, and hardens the Azure VM Terraform by keeping SSH closed unless explicit CIDRs are provided.

It also ignores local Terraform state/artifacts and keeps the Azure deploy README/tfvars example aligned with the new workflow.

Testing:
- npm run lint:frontend
- npm run test:smoke

Reviewer focus:
- draft restore path on terminal reload
- startup no longer overwriting saved drafts
- Azure NSG SSH default staying closed unless configured