### PR TITLE
Drafts In Terminal

### DIFF
--- a/CSS/terminal/editor.css
+++ b/CSS/terminal/editor.css
@@ -59,16 +59,17 @@
 .draft-recovery-banner {
   display: flex;
   align-items: center;
-  gap: 8px;
-  padding: 7px 12px;
-  background: #182535;
-  border-bottom: 1px solid #2f4a67;
-  border-top: 1px solid #2f4a67;
-  font-size: 12px;
+  gap: 10px;
+  padding: 9px 14px;
+  background: linear-gradient(to bottom, #111a2e, #0d1626);
+  border-bottom: 1px solid #1e3050;
+  border-top: 1px solid #1e3050;
+  font-size: 12.5px;
   color: #c8dbf3;
   font-family: 'Space Grotesk', sans-serif;
-  animation: slideDown 0.2s ease;
+  animation: slideDown 0.25s ease;
   flex-shrink: 0;
+  box-shadow: 0 2px 8px rgba(0,0,0,0.25);
 }
 
 @keyframes slideDown {
@@ -92,33 +93,37 @@
 }
 
 .draft-recovery-discard {
-  padding: 3px 10px;
+  padding: 4px 12px;
   background: transparent;
-  border: 1px solid #fb4934;
-  border-radius: 4px;
-  color: #fb4934;
-  font-size: 11px;
+  border: 1px solid var(--bg3, #2f4a67);
+  border-radius: 6px;
+  color: var(--fg2, #c8dbf3);
+  font-size: 11.5px;
+  font-weight: 600;
   font-family: inherit;
   cursor: pointer;
-  transition: background 0.15s;
+  transition: background 0.15s, border-color 0.15s;
 }
 .draft-recovery-discard:hover {
-  background: rgba(251, 73, 52, 0.12);
+  background: var(--bg2, #213448);
+  border-color: var(--fg4, #7e9ac0);
 }
 
 .draft-recovery-browse {
-  padding: 3px 10px;
+  padding: 4px 12px;
   background: transparent;
-  border: 1px solid var(--accent, #4ea0ff);
-  border-radius: 4px;
-  color: var(--accent, #4ea0ff);
-  font-size: 11px;
+  border: 1px solid var(--bg3, #2f4a67);
+  border-radius: 6px;
+  color: var(--fg2, #c8dbf3);
+  font-size: 11.5px;
+  font-weight: 600;
   font-family: inherit;
   cursor: pointer;
-  transition: background 0.15s;
+  transition: background 0.15s, border-color 0.15s;
 }
 .draft-recovery-browse:hover {
-  background: rgba(78, 160, 255, 0.12);
+  background: var(--bg2, #213448);
+  border-color: var(--fg4, #7e9ac0);
 }
 
 .draft-recovery-dismiss {
@@ -134,4 +139,132 @@
 }
 .draft-recovery-dismiss:hover {
   background: var(--bg2, #213448);
+}
+
+
+.draft-browse-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(7, 12, 18, 0.6);
+  display: flex;
+  align-items: flex-start;
+  justify-content: center;
+  padding-top: 14vh;
+  z-index: 80;
+}
+
+.draft-browse-modal {
+  width: min(560px, calc(100vw - 32px));
+  max-height: 70vh;
+  display: flex;
+  flex-direction: column;
+  border: 1px solid var(--bg3, #2f4a67);
+  border-radius: 12px;
+  background: var(--bg0, #111a25);
+  overflow: hidden;
+  box-shadow: 0 30px 80px rgba(0, 0, 0, 0.45);
+  animation: draftModalIn 0.18s ease;
+}
+
+@keyframes draftModalIn {
+  from { opacity: 0; transform: translateY(-8px) scale(0.98); }
+  to   { opacity: 1; transform: translateY(0) scale(1); }
+}
+
+.draft-browse-head {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 12px 14px;
+  border-bottom: 1px solid var(--bg2, #213448);
+  font-size: 13px;
+  font-weight: 700;
+  color: var(--fg1, #e6effa);
+  font-family: 'Space Grotesk', sans-serif;
+  flex-shrink: 0;
+}
+
+.draft-browse-close {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 24px;
+  height: 24px;
+  padding: 0;
+  background: transparent;
+  border: none;
+  border-radius: 6px;
+  color: var(--fg3, #9db8d9);
+  font-size: 13px;
+  cursor: pointer;
+  transition: background 0.15s, color 0.15s;
+}
+.draft-browse-close:hover {
+  background: var(--bg2, #213448);
+  color: var(--fg1, #e6effa);
+}
+
+.draft-browse-subhead {
+  padding: 8px 14px;
+  font-size: 11.5px;
+  color: var(--fg4, #7e9ac0);
+  font-family: 'Space Grotesk', sans-serif;
+  border-bottom: 1px solid var(--bg2, #213448);
+  flex-shrink: 0;
+}
+
+.draft-browse-list {
+  overflow-y: auto;
+  flex: 1;
+}
+
+.draft-browse-item {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+  width: 100%;
+  text-align: left;
+  padding: 11px 14px;
+  border: 0;
+  border-bottom: 1px solid var(--bg2, #213448);
+  background: transparent;
+  cursor: pointer;
+  font-family: inherit;
+  transition: background 0.15s;
+}
+
+.draft-browse-item:last-child {
+  border-bottom: 0;
+}
+
+.draft-browse-item:hover {
+  background: var(--bg1, #182535);
+}
+
+.draft-browse-item-label {
+  font-size: 12.5px;
+  font-weight: 600;
+  color: var(--fg1, #e6effa);
+  font-family: 'Space Grotesk', sans-serif;
+}
+
+.draft-browse-item-preview {
+  font-size: 11px;
+  color: var(--fg3, #9db8d9);
+  font-family: 'JetBrains Mono', 'Fira Code', monospace;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+
+.draft-browse-list::-webkit-scrollbar {
+  width: 8px;
+}
+.draft-browse-list::-webkit-scrollbar-track {
+  background: var(--bg1, #182535);
+}
+.draft-browse-list::-webkit-scrollbar-thumb {
+  background: var(--bg3, #2f4a67);
+  border-radius: 4px;
 }

--- a/Javascript/terminal/app/core.js
+++ b/Javascript/terminal/app/core.js
@@ -384,9 +384,6 @@ function restoreDraftOrDefault(fallback) {
   if (saved !== null) {
     try {
       editor.setValue(saved);
-      if (typeof showDraftRecoveryBanner === 'function') {
-        showDraftRecoveryBanner();
-      }
     } catch (e) {
       console.warn('Draft restore failed, falling back:', e);
       editor.setValue(fallback);

--- a/Javascript/terminal/app/core.js
+++ b/Javascript/terminal/app/core.js
@@ -420,7 +420,7 @@ function queueDraftSave() {
     return;
   }
   window.clearTimeout(autoSaveTimer);
-  autoSaveTimer = window.setTimeout(persistActiveDraft, 10000);
+  autoSaveTimer = window.setTimeout(persistActiveDraft, 250);
 }
 
 function flushDraftSave() {

--- a/Javascript/terminal/app/core.js
+++ b/Javascript/terminal/app/core.js
@@ -384,6 +384,9 @@ function restoreDraftOrDefault(fallback) {
   if (saved !== null) {
     try {
       editor.setValue(saved);
+      if (typeof showDraftRecoveryBanner === 'function') {
+        showDraftRecoveryBanner();
+      }
     } catch (e) {
       console.warn('Draft restore failed, falling back:', e);
       editor.setValue(fallback);

--- a/Javascript/terminal/app/core.js
+++ b/Javascript/terminal/app/core.js
@@ -345,8 +345,6 @@ function getSavedDraftSummaries() {
         return;
       }
  
-      const challenge = challengeCatalog[challengeId];
-      const challengeTitle = challenge ? challenge.title : challengeId;
       const preview = value
         .split('\n')
         .find((line) => line.trim().length > 0);

--- a/Javascript/terminal/app/core.js
+++ b/Javascript/terminal/app/core.js
@@ -384,6 +384,9 @@ function restoreDraftOrDefault(fallback) {
   if (saved !== null) {
     try {
       editor.setValue(saved);
+      if (typeof showDraftRecoveryBanner === 'function') {
+        showDraftRecoveryBanner();
+      }
     } catch (e) {
       console.warn('Draft restore failed, falling back:', e);
       editor.setValue(fallback);
@@ -403,6 +406,9 @@ function persistActiveDraft() {
     // Don't save a draft that's identical to the unmodified starter —
     // there's nothing to "recover" in that case.
     if (value === starterValue) {
+      if (activeEditorFile.kind === 'template') {
+        localStorage.removeItem(getDraftStorageKey());
+      }
       return;
     }
     localStorage.setItem(getDraftStorageKey(), value);

--- a/Javascript/terminal/app/core.js
+++ b/Javascript/terminal/app/core.js
@@ -333,45 +333,65 @@ function getDraftStorageKey() {
 function getSavedDraftSummaries() {
   const prefix = `${DRAFT_STORAGE_PREFIX}:`;
   const summaries = [];
-
+ 
   try {
     Object.keys(localStorage).forEach((key) => {
       if (!key.startsWith(prefix)) {
         return;
       }
-
-      const parts = key.slice(prefix.length).split(':');
+ 
+      const rest = key.slice(prefix.length);
+      let isDiscarded = false;
+      let lookupRest = rest;
+ 
+      // Discarded drafts are stored as: discarded:{timestamp}:{challengeId}:{kind}:{scope}
+      if (rest.startsWith('discarded:')) {
+        isDiscarded = true;
+        const afterDiscarded = rest.slice('discarded:'.length);
+        const firstColon = afterDiscarded.indexOf(':');
+        lookupRest = afterDiscarded.slice(firstColon + 1);
+      }
+ 
+      const parts = lookupRest.split(':');
       const challengeId = parts[0];
       const kind = parts[1];
       const scope = parts.slice(2).join(':');
       if (!challengeId || !kind || !scope) {
         return;
       }
-
+ 
       const value = localStorage.getItem(key);
       if (value === null) {
         return;
       }
-
+ 
       const challenge = challengeCatalog[challengeId];
       const challengeTitle = challenge ? challenge.title : challengeId;
       const preview = value
         .split('\n')
         .find((line) => line.trim().length > 0);
+ 
       summaries.push({
         key,
         challengeId,
         kind,
         scope,
-        label: `${challengeTitle} - ${kind === 'workspace' ? scope : scope}`,
+        isDiscarded,
+        label: isDiscarded
+          ? `${scope} (discarded — click to restore)`
+          : scope,
         preview: preview || '(empty draft)',
       });
     });
   } catch (e) {
     console.warn('Draft list failed:', e);
   }
-
-  return summaries.sort((a, b) => a.label.localeCompare(b.label));
+ 
+  // Active drafts first, then discarded ones
+  return summaries.sort((a, b) => {
+    if (a.isDiscarded !== b.isDiscarded) return a.isDiscarded ? 1 : -1;
+    return a.label.localeCompare(b.label);
+  });
 }
 
 function restoreDraftOrDefault(fallback) {
@@ -403,18 +423,29 @@ function persistActiveDraft() {
     return;
   }
   try {
-    localStorage.setItem(getDraftStorageKey(), editor.getValue());
+    const value = editor.getValue();
+    const starterValue = codeSamples[currentLang] || '';
+    // Don't save a draft that's identical to the unmodified starter —
+    // there's nothing to "recover" in that case.
+    if (value === starterValue) {
+      return;
+    }
+    localStorage.setItem(getDraftStorageKey(), value);
   } catch (e) {
     console.warn('Draft save failed:', e);
   }
 }
 
+/**
+ * Debounced draft save. Waits 30 seconds after the user stops typing
+ * before persisting to localStorage, so drafts aren't rewritten on every keystroke.
+ */
 function queueDraftSave() {
   if (!editor) {
     return;
   }
   window.clearTimeout(autoSaveTimer);
-  autoSaveTimer = window.setTimeout(persistActiveDraft, 250);
+  autoSaveTimer = window.setTimeout(persistActiveDraft, 10000);
 }
 
 function setMobileView(view) {
@@ -523,7 +554,7 @@ function renderFileTabs() {
 
 function switchLanguage(lang, options = {}) {
   const { persistCurrent = true } = options;
-  if (editor && persistCurrent) {
+  if (editor && persistCurrent && !isInitialLoad) {
     persistActiveDraft();
   }
 

--- a/Javascript/terminal/app/core.js
+++ b/Javascript/terminal/app/core.js
@@ -420,7 +420,7 @@ function queueDraftSave() {
     return;
   }
   window.clearTimeout(autoSaveTimer);
-  autoSaveTimer = window.setTimeout(persistActiveDraft, 250);
+  persistActiveDraft();
 }
 
 function flushDraftSave() {

--- a/Javascript/terminal/app/ui.js
+++ b/Javascript/terminal/app/ui.js
@@ -71,6 +71,9 @@ function handleGlobalShortcuts(event) {
   }
 }
 
+/**
+ * Show a banner above the editor when a non-default draft was restored.
+ */
 function showDraftRecoveryBanner() {
   const existing = document.getElementById('draftRecoveryBanner');
   if (existing) existing.remove();
@@ -80,7 +83,7 @@ function showDraftRecoveryBanner() {
   banner.id = 'draftRecoveryBanner';
   banner.className = 'draft-recovery-banner';
   banner.innerHTML = `
-    <span class="draft-recovery-icon">&#128196;</span>
+    <span class="draft-recovery-icon"></span>
     <span class="draft-recovery-msg">Draft recovered from your last session.</span>
     ${
       hasMultipleDrafts
@@ -118,66 +121,136 @@ function showDraftRecoveryBanner() {
   }, 8000);
 }
 
+/**
+ * Discard the active draft and reset the editor to the original language default
+ * (not the challenge's hint-laden starter code).
+ */
 function discardActiveDraft() {
+  const key = getDraftStorageKey();
+ 
   try {
-    const key = getDraftStorageKey();
+    const discardedContent = localStorage.getItem(key);
+    if (discardedContent !== null) {
+      // Archive under a "discarded:" prefix so it still appears in Browse,
+      // labeled clearly, in case the student wants it back.
+      const archiveKey = `${DRAFT_STORAGE_PREFIX}:discarded:${Date.now()}:${key.slice(DRAFT_STORAGE_PREFIX.length + 1)}`;
+      localStorage.setItem(archiveKey, discardedContent);
+    }
     localStorage.removeItem(key);
   } catch (e) {
     console.warn('Draft discard failed:', e);
   }
-
+ 
   const banner = document.getElementById('draftRecoveryBanner');
   if (banner) banner.remove();
-
-  const challenge = challengeCatalog[activeChallengeId];
-  const starterLang = challenge?.starterLang || currentLang;
-  const starterCode = challenge?.starterCode || codeSamples[starterLang] || '';
-  currentLang = starterLang;
-  codeSamples[currentLang] = starterCode;
+ 
+  const originalDefaults = {
+    python: '# Python starter\nprint("CyberMinds terminal ready")\n',
+    javascript: '// JavaScript starter\nconsole.log("CyberMinds terminal ready");\n',
+    java: 'public class Hello {\n    public static void main(String[] args) {\n        System.out.println("CyberMinds terminal ready");\n    }\n}\n',
+    go: 'package main\n\nimport "fmt"\n\nfunc main() {\n\tfmt.Println("CyberMinds terminal ready")\n}\n',
+  };
+  const defaultCode = originalDefaults[currentLang] || '';
+ 
+  codeSamples[currentLang] = defaultCode;
   activeEditorFile = {
     kind: 'template',
     lang: currentLang,
     filename: templateFilenames[currentLang],
     path: '',
   };
-  editor.setValue(starterCode);
+  editor.setValue(defaultCode);
   monaco.editor.setModelLanguage(editor.getModel(), currentLang);
   renderFileTabs();
   refreshLanguageBadge();
-  persistActiveDraft();
-  showToast('Draft discarded. Starter code loaded.');
+  showToast('Draft discarded. You can still recover it from Browse Drafts.');
 }
 
+/**
+ * Open a styled modal listing all saved drafts across challenges/files.
+ * Replaces the old window.prompt()-based browser.
+ */
 function browseSavedDrafts() {
-  const drafts = getSavedDraftSummaries();
-  if (drafts.length === 0) {
-    showToast('No saved drafts found.');
-    return;
-  }
+  const allDrafts = getSavedDraftSummaries();
 
-  const choices = drafts
-    .map((draft, index) => {
-      const preview =
-        draft.preview.length > 60
-          ? `${draft.preview.slice(0, 57)}...`
-          : draft.preview;
-      return `${index + 1}. ${draft.label} - ${preview}`;
-    })
-    .join('\n');
-  const selection = window.prompt(
-    `Saved drafts stay in this browser only.\n\n${choices}\n\nEnter a draft number to restore:`
+  // Scope to the current challenge only — show all files/languages for this challenge
+  const drafts = allDrafts.filter(
+    (draft) => draft.challengeId === activeChallengeId
   );
-  if (selection === null) {
+
+  if (drafts.length === 0) {
+    showToast('No saved drafts found for this challenge.');
     return;
   }
 
-  const index = Number.parseInt(selection, 10) - 1;
-  if (!Number.isInteger(index) || index < 0 || index >= drafts.length) {
-    showToast('No draft restored.');
-    return;
+  const existing = document.getElementById('draftBrowseOverlay');
+  if (existing) existing.remove();
+
+  const overlay = document.createElement('div');
+  overlay.id = 'draftBrowseOverlay';
+  overlay.className = 'draft-browse-overlay';
+
+  const modal = document.createElement('div');
+  modal.className = 'draft-browse-modal';
+  modal.setAttribute('role', 'dialog');
+  modal.setAttribute('aria-modal', 'true');
+
+  const challengeTitle = challengeCatalog[activeChallengeId]?.title || activeChallengeId;
+
+  modal.innerHTML = `
+    <div class="draft-browse-head">
+      <span>Saved Drafts — ${challengeTitle}</span>
+      <button class="draft-browse-close" id="draftBrowseCloseBtn" type="button">&#10005;</button>
+    </div>
+    <div class="draft-browse-subhead">Saved drafts stay in this browser only.</div>
+    <div class="draft-browse-list" id="draftBrowseList"></div>
+  `;
+
+  overlay.appendChild(modal);
+  document.body.appendChild(overlay);
+
+  const list = modal.querySelector('#draftBrowseList');
+  drafts.forEach((draft) => {
+    const item = document.createElement('button');
+    item.type = 'button';
+    item.className = 'draft-browse-item';
+
+    const preview =
+      draft.preview.length > 70
+        ? `${draft.preview.slice(0, 67)}...`
+        : draft.preview;
+
+    item.innerHTML = `
+      <span class="draft-browse-item-label">${draft.scope}</span>
+      <span class="draft-browse-item-preview">${preview}</span>
+    `;
+
+    item.addEventListener('click', () => {
+      restoreSavedDraft(draft);
+      overlay.remove();
+    });
+
+    list.appendChild(item);
+  });
+
+  function closeModal() {
+    overlay.remove();
   }
 
-  restoreSavedDraft(drafts[index]);
+  modal.querySelector('#draftBrowseCloseBtn').addEventListener('click', closeModal);
+  overlay.addEventListener('click', (event) => {
+    if (event.target === overlay) {
+      closeModal();
+    }
+  });
+
+  const escHandler = (event) => {
+    if (event.key === 'Escape') {
+      closeModal();
+      document.removeEventListener('keydown', escHandler);
+    }
+  };
+  document.addEventListener('keydown', escHandler);
 }
 
 function restoreSavedDraft(draft) {
@@ -187,14 +260,14 @@ function restoreSavedDraft(draft) {
   } catch (e) {
     console.warn('Draft restore failed:', e);
   }
-
+ 
   if (saved === null) {
     showToast('Saved draft was not found.');
     return;
   }
-
+ 
   loadChallenge(draft.challengeId);
-
+ 
   if (draft.kind === 'workspace') {
     const language = detectLanguageFromPath(draft.scope);
     currentLang = language;
@@ -218,10 +291,21 @@ function restoreSavedDraft(draft) {
     switchLanguage(draft.scope, { persistCurrent: false });
     editor.setValue(saved);
   }
-
+ 
+  // If this was a discarded/archived draft, promote it back to the active key
+  // and clean up the archive entry.
+  if (draft.isDiscarded) {
+    try {
+      localStorage.removeItem(draft.key);
+    } catch (e) {
+      console.warn('Failed to clean up archived draft:', e);
+    }
+  }
+  persistActiveDraft();
+ 
   const banner = document.getElementById('draftRecoveryBanner');
   if (banner) banner.remove();
-  showToast('Saved draft restored.');
+  showToast(draft.isDiscarded ? 'Discarded draft restored.' : 'Saved draft restored.');
 }
 
 function attachUiHandlers() {
@@ -466,6 +550,11 @@ function initEditor() {
     renderFileTabs();
     loadChallenge(activeChallengeId, false);
 
+    // Mark initial load complete after boot settles so switchLanguage/persistActiveDraft
+    // calls during boot don't overwrite a freshly-restored draft.
+    window.setTimeout(() => {
+      isInitialLoad = false;
+    }, 500);
   });
 }
 

--- a/Javascript/terminal/app/ui.js
+++ b/Javascript/terminal/app/ui.js
@@ -127,43 +127,34 @@ function showDraftRecoveryBanner() {
  */
 function discardActiveDraft() {
   const key = getDraftStorageKey();
- 
+
   try {
-    const discardedContent = localStorage.getItem(key);
-    if (discardedContent !== null) {
-      // Archive under a "discarded:" prefix so it still appears in Browse,
-      // labeled clearly, in case the student wants it back.
-      const archiveKey = `${DRAFT_STORAGE_PREFIX}:discarded:${Date.now()}:${key.slice(DRAFT_STORAGE_PREFIX.length + 1)}`;
-      localStorage.setItem(archiveKey, discardedContent);
-    }
     localStorage.removeItem(key);
   } catch (e) {
     console.warn('Draft discard failed:', e);
   }
- 
+
   const banner = document.getElementById('draftRecoveryBanner');
   if (banner) banner.remove();
- 
-  const originalDefaults = {
-    python: '# Python starter\nprint("CyberMinds terminal ready")\n',
-    javascript: '// JavaScript starter\nconsole.log("CyberMinds terminal ready");\n',
-    java: 'public class Hello {\n    public static void main(String[] args) {\n        System.out.println("CyberMinds terminal ready");\n    }\n}\n',
-    go: 'package main\n\nimport "fmt"\n\nfunc main() {\n\tfmt.Println("CyberMinds terminal ready")\n}\n',
-  };
-  const defaultCode = originalDefaults[currentLang] || '';
- 
-  codeSamples[currentLang] = defaultCode;
-  activeEditorFile = {
-    kind: 'template',
-    lang: currentLang,
-    filename: templateFilenames[currentLang],
-    path: '',
-  };
-  editor.setValue(defaultCode);
-  monaco.editor.setModelLanguage(editor.getModel(), currentLang);
-  renderFileTabs();
-  refreshLanguageBadge();
-  showToast('Draft discarded. You can still recover it from Browse Drafts.');
+
+  if (activeEditorFile.kind === 'workspace') {
+    openWorkspaceFile(activeEditorFile.path);
+    showToast('Draft discarded.');
+    return;
+  }
+
+  const challenge = challengeCatalog[activeChallengeId];
+  if (!challenge) {
+    editor.setValue(codeSamples[currentLang] || '');
+    showToast('Draft discarded.');
+    return;
+  }
+
+  currentLang = challenge.starterLang;
+  codeSamples[currentLang] = challenge.starterCode;
+  switchLanguage(currentLang, { persistCurrent: false });
+  editor.setValue(challenge.starterCode);
+  showToast('Draft discarded.');
 }
 
 /**
@@ -220,10 +211,16 @@ function browseSavedDrafts() {
         ? `${draft.preview.slice(0, 67)}...`
         : draft.preview;
 
-    item.innerHTML = `
-      <span class="draft-browse-item-label">${draft.scope}</span>
-      <span class="draft-browse-item-preview">${preview}</span>
-    `;
+    const label = document.createElement('span');
+    label.className = 'draft-browse-item-label';
+    label.textContent = draft.scope;
+
+    const previewLine = document.createElement('span');
+    previewLine.className = 'draft-browse-item-preview';
+    previewLine.textContent = preview;
+
+    item.appendChild(label);
+    item.appendChild(previewLine);
 
     item.addEventListener('click', () => {
       restoreSavedDraft(draft);

--- a/Javascript/terminal/app/ui.js
+++ b/Javascript/terminal/app/ui.js
@@ -143,26 +143,16 @@ function discardActiveDraft() {
  
   const banner = document.getElementById('draftRecoveryBanner');
   if (banner) banner.remove();
- 
-  const originalDefaults = {
-    python: '# Python starter\nprint("CyberMinds terminal ready")\n',
-    javascript: '// JavaScript starter\nconsole.log("CyberMinds terminal ready");\n',
-    java: 'public class Hello {\n    public static void main(String[] args) {\n        System.out.println("CyberMinds terminal ready");\n    }\n}\n',
-    go: 'package main\n\nimport "fmt"\n\nfunc main() {\n\tfmt.Println("CyberMinds terminal ready")\n}\n',
-  };
-  const defaultCode = originalDefaults[currentLang] || '';
- 
-  codeSamples[currentLang] = defaultCode;
-  activeEditorFile = {
-    kind: 'template',
-    lang: currentLang,
-    filename: templateFilenames[currentLang],
-    path: '',
-  };
-  editor.setValue(defaultCode);
-  monaco.editor.setModelLanguage(editor.getModel(), currentLang);
-  renderFileTabs();
-  refreshLanguageBadge();
+
+  const challenge = challengeCatalog[activeChallengeId];
+  if (challenge) {
+    currentLang = challenge.starterLang;
+    codeSamples[currentLang] = challenge.starterCode;
+    switchLanguage(currentLang, { persistCurrent: false });
+    editor.setValue(challenge.starterCode);
+  } else {
+    editor.setValue(codeSamples[currentLang] || '');
+  }
   showToast('Draft discarded. You can still recover it from Browse Drafts.');
 }
 

--- a/Javascript/terminal/app/ui.js
+++ b/Javascript/terminal/app/ui.js
@@ -143,16 +143,26 @@ function discardActiveDraft() {
  
   const banner = document.getElementById('draftRecoveryBanner');
   if (banner) banner.remove();
-
-  const challenge = challengeCatalog[activeChallengeId];
-  if (challenge) {
-    currentLang = challenge.starterLang;
-    codeSamples[currentLang] = challenge.starterCode;
-    switchLanguage(currentLang, { persistCurrent: false });
-    editor.setValue(challenge.starterCode);
-  } else {
-    editor.setValue(codeSamples[currentLang] || '');
-  }
+ 
+  const originalDefaults = {
+    python: '# Python starter\nprint("CyberMinds terminal ready")\n',
+    javascript: '// JavaScript starter\nconsole.log("CyberMinds terminal ready");\n',
+    java: 'public class Hello {\n    public static void main(String[] args) {\n        System.out.println("CyberMinds terminal ready");\n    }\n}\n',
+    go: 'package main\n\nimport "fmt"\n\nfunc main() {\n\tfmt.Println("CyberMinds terminal ready")\n}\n',
+  };
+  const defaultCode = originalDefaults[currentLang] || '';
+ 
+  codeSamples[currentLang] = defaultCode;
+  activeEditorFile = {
+    kind: 'template',
+    lang: currentLang,
+    filename: templateFilenames[currentLang],
+    path: '',
+  };
+  editor.setValue(defaultCode);
+  monaco.editor.setModelLanguage(editor.getModel(), currentLang);
+  renderFileTabs();
+  refreshLanguageBadge();
   showToast('Draft discarded. You can still recover it from Browse Drafts.');
 }
 

--- a/Javascript/terminal/state.js
+++ b/Javascript/terminal/state.js
@@ -26,6 +26,7 @@ let activeEditorFile = {
   filename: 'hello.py',
   path: '',
 };
+let isInitialLoad = true;
 const PROGRESS_STORAGE_KEY = 'cm_ctf_progress_v1';
 const THEME_STORAGE_KEY = 'cm_terminal_theme_v1';
 const DRAFT_STORAGE_PREFIX = 'cm_terminal_draft_v1';

--- a/tests/smoke.spec.js
+++ b/tests/smoke.spec.js
@@ -197,9 +197,9 @@ test.describe('Content pages', () => {
       'Our Mission'
     );
 
-    const overflowing = await page.evaluate(() => {
-      return document.documentElement.scrollWidth > window.innerWidth;
-    });
+    const overflowing = await page.evaluate(
+      () => document.documentElement.scrollWidth > window.innerWidth
+    );
     expect(overflowing).toBe(false);
   });
 
@@ -574,9 +574,36 @@ test.describe('Mock terminal', () => {
     );
 
     expect(restoredDraft).toContain('keep this after reload');
-    await expect(page.locator('#draftRecoveryBanner')).toHaveCount(0);
+    await expect(page.locator('#draftRecoveryBanner')).toHaveCount(1);
 
     await expect(page.locator('#editor')).toContainText(
+      'keep this after reload'
+    );
+
+    page.once('dialog', (dialog) => dialog.accept());
+    await page.locator('#draftDiscardBtn').click();
+
+    const clearedDraft = await page.evaluate(() =>
+      window.localStorage.getItem(
+        'cm_terminal_draft_v1:linux-basics:template:python'
+      )
+    );
+    expect(clearedDraft).toBeNull();
+
+    await expect(page.locator('#editor')).toContainText(
+      'Linux Basics Warmup'
+    );
+
+    await page.reload();
+    await waitForMockReady(page);
+    await page.waitForFunction(
+      () => !!window.__cybermindsMonacoEditor,
+      null,
+      { timeout: 10_000 }
+    );
+
+    await expect(page.locator('#draftRecoveryBanner')).toHaveCount(0);
+    await expect(page.locator('#editor')).not.toContainText(
       'keep this after reload'
     );
   });


### PR DESCRIPTION
- Drafts save when switching files/tabs
- Redesigned the recovery banner and "Browse Drafts" popup 
- Browse Drafts is now scoped to the current challenge only, instead of showing every draft across all challenges 
- Still refining which draft versions get saved (avoiding saving unmodified starter code as a "draft") to make recovery behavior clearer
- Still refining how often draft popup will show up