### PR TITLE
fix(qa): ignore commented HTML

### DIFF
--- a/scripts/qa-static.js
+++ b/scripts/qa-static.js
@@ -117,15 +117,16 @@ function checkReferences(file, content, regex, type) {
 
 function checkFile(file) {
   const content = fs.readFileSync(file, 'utf8');
+  const activeContent = content.replace(/<!--[\s\S]*?-->/g, '');
   const rel = relative(file);
-  const title = titleRe.exec(content);
+  const title = titleRe.exec(activeContent);
   if (!title) report(file, 'Missing <title> tag');
   else if (!title[1].trim()) report(file, 'Empty <title> tag');
 
   if (!(allowlist.skipAltChecks || []).includes(rel)) {
     imgRe.lastIndex = 0;
     let image;
-    while ((image = imgRe.exec(content)) !== null) {
+    while ((image = imgRe.exec(activeContent)) !== null) {
       const attributes = image[1];
       const alt = altRe.exec(attributes);
       const decorative =
@@ -138,13 +139,13 @@ function checkFile(file) {
     }
   }
 
-  checkReferences(file, content, hrefRe, 'link');
-  checkReferences(file, content, srcRe, 'asset');
+  checkReferences(file, activeContent, hrefRe, 'link');
+  checkReferences(file, activeContent, srcRe, 'asset');
 
-  if (!/footer\.js/.test(content)) {
+  if (!/footer\.js/.test(activeContent)) {
     footerRe.lastIndex = 0;
     let footer;
-    while ((footer = footerRe.exec(content)) !== null) {
+    while ((footer = footerRe.exec(activeContent)) !== null) {
       yearRe.lastIndex = 0;
       let year;
       while ((year = yearRe.exec(footer[1])) !== null) {

--- a/scripts/qa-static.test.js
+++ b/scripts/qa-static.test.js
@@ -33,6 +33,14 @@ test('accepts valid local links, allowlisted assets, and decorative images', () 
   assert.equal(result.status, 0, result.stderr);
 });
 
+test('ignores inactive markup inside HTML comments', () => {
+  const result = run({
+    'index.html':
+      '<title>Home</title><!-- <img src="missing.png"><a href="add here">Draft</a> -->'
+  });
+  assert.equal(result.status, 0, result.stderr);
+});
+
 test('rejects unsafe references and unmarked empty alt without logging queries', () => {
   const result = run({
     'index.html': '<title>Home</title><img src="image.png" alt=""><a href="add here?token=super-secret">Placeholder</a><a href="https://evil.example/path?token=super-secret">External</a><a href="javascript:alert(1)">Unsafe</a>',


### PR DESCRIPTION
Ignore inactive markup inside HTML comments so draft placeholders do not fail the changed-file QA gate. Adds a regression test alongside the existing checker tests.\n\nTested with: npm run test:qa