### PR TITLE
fix(terminal): bound HTTP connection setup

### DIFF
--- a/terminal/backend/main.go
+++ b/terminal/backend/main.go
@@ -4,6 +4,7 @@ import (
 	"log"
 	"net/http"
 	"os"
+	"time"
 
 	"github.com/gorilla/mux"
 )
@@ -40,5 +41,15 @@ func main() {
 	log.Printf("Server starting on port %s", port)
 	log.Printf("Environment: %s", getEnvironment())
 	log.Printf("Session limits: max_active=%d create_per_minute=%d", maxActiveSessions, createRatePerMinute)
-	log.Fatal(http.ListenAndServe(":"+port, router))
+	log.Fatal(newHTTPServer(":"+port, router).ListenAndServe())
+}
+
+func newHTTPServer(addr string, handler http.Handler) *http.Server {
+	return &http.Server{
+		Addr:              addr,
+		Handler:           handler,
+		ReadHeaderTimeout: 5 * time.Second,
+		IdleTimeout:       60 * time.Second,
+		MaxHeaderBytes:    64 << 10,
+	}
 }

--- a/terminal/backend/main_test.go
+++ b/terminal/backend/main_test.go
@@ -1,0 +1,24 @@
+package main
+
+import (
+	"net/http"
+	"testing"
+	"time"
+)
+
+func TestNewHTTPServerBoundsConnectionsWithoutTimingOutWebSockets(t *testing.T) {
+	server := newHTTPServer(":0", http.NotFoundHandler())
+
+	if server.ReadHeaderTimeout != 5*time.Second {
+		t.Fatalf("ReadHeaderTimeout = %v, want 5s", server.ReadHeaderTimeout)
+	}
+	if server.IdleTimeout != 60*time.Second {
+		t.Fatalf("IdleTimeout = %v, want 1m", server.IdleTimeout)
+	}
+	if server.MaxHeaderBytes != 64<<10 {
+		t.Fatalf("MaxHeaderBytes = %d, want %d", server.MaxHeaderBytes, 64<<10)
+	}
+	if server.ReadTimeout != 0 || server.WriteTimeout != 0 {
+		t.Fatal("whole-request timeouts must remain unset for WebSocket streams")
+	}
+}


### PR DESCRIPTION
The production terminal API now limits slow request headers, idle keep-alive connections, and header size at the Go server boundary. The configuration intentionally leaves whole-request read and write deadlines unset so long-lived WebSocket terminal streams keep working.

Closes #171.

## What changed

- replace the zero-value `http.ListenAndServe` helper with an explicit `http.Server`
- enforce a 5-second header deadline, 60-second idle timeout, and 64 KiB header limit
- add a focused regression test that locks those limits and the WebSocket timeout behavior

## Validation

- `go test -race ./...`
- `go vet ./...`
- `git diff --check`

## Review focus

- confirm the limits are conservative for normal API traffic
- confirm leaving `ReadTimeout` and `WriteTimeout` unset is appropriate for the WebSocket endpoint
